### PR TITLE
feat(landing): refonte moderne de la page vitrine

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -3,32 +3,40 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="CeSlack — La plateforme pédagogique pour votre formation CESI. Messagerie, devoirs, documents et suivi en un seul endroit." />
+  <meta name="description" content="CeSlack — La plateforme pedagogique pour votre formation CESI. Messagerie, devoirs, documents et suivi en un seul endroit." />
   <meta name="theme-color" content="#4A90D9" />
-  <title>CeSlack — Plateforme pédagogique</title>
+  <title>CeSlack — Plateforme pedagogique</title>
   <link rel="icon" type="image/png" href="/assets/icon-192.png" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;600;700;800;900&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet" />
+  <!-- Lucide Icons CDN -->
+  <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js" defer></script>
   <style>
     /* ═══ Reset ═══ */
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
     html { scroll-behavior: smooth; }
 
-    /* ═══ Variables ═══ */
     :root {
-      --bg: #0b0d11;
-      --bg-card: #14161c;
-      --bg-card-hover: #1a1d24;
+      --bg: #08090c;
+      --bg-elevated: #0f1117;
+      --bg-card: #13151b;
+      --bg-card-hover: #191c24;
       --accent: #4A90D9;
       --accent-hover: #5da3f0;
-      --accent-glow: rgba(74,144,217,.2);
-      --text: #D1D2D3;
-      --text-secondary: #8b8e94;
-      --text-muted: #555860;
+      --accent-glow: rgba(74,144,217,.15);
+      --accent-glow-strong: rgba(74,144,217,.3);
+      --purple: #9b87f5;
+      --green: #2ECC71;
+      --orange: #F39C12;
+      --text: #e2e4e8;
+      --text-secondary: #8b8f98;
+      --text-muted: #4e5260;
       --border: rgba(255,255,255,.06);
-      --radius: 14px;
-      --font: 'Lato', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      --border-accent: rgba(74,144,217,.15);
+      --radius: 16px;
+      --radius-sm: 10px;
+      --font: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
     }
 
     body {
@@ -37,340 +45,311 @@
       color: var(--text);
       -webkit-font-smoothing: antialiased;
       overflow-x: hidden;
+      line-height: 1.6;
     }
 
-    a { color: var(--accent); text-decoration: none; }
+    a { color: var(--accent); text-decoration: none; transition: color .15s; }
     a:hover { color: var(--accent-hover); }
 
-    /* ═══ Layout ═══ */
-    .container {
-      max-width: 1120px;
-      margin: 0 auto;
-      padding: 0 24px;
-    }
+    .container { max-width: 1100px; margin: 0 auto; padding: 0 24px; }
 
     /* ═══ Nav ═══ */
     .nav {
-      position: fixed;
-      top: 0; left: 0; right: 0;
-      z-index: 100;
-      padding: 14px 0;
-      background: rgba(11,13,17,.85);
-      backdrop-filter: blur(16px);
+      position: fixed; top: 0; left: 0; right: 0; z-index: 100;
+      padding: 12px 0;
+      background: rgba(8,9,12,.8);
+      backdrop-filter: blur(20px) saturate(1.4);
       border-bottom: 1px solid var(--border);
     }
-    .nav .container {
-      display: flex;
-      align-items: center;
-      gap: 16px;
-    }
-    .nav-logo {
-      display: flex;
-      align-items: center;
-      gap: 10px;
-      font-size: 18px;
-      font-weight: 800;
-      letter-spacing: -.4px;
-    }
-    .nav-logo img { width: 32px; height: 32px; }
-    .nav-links {
-      display: flex;
-      gap: 28px;
-      margin-left: auto;
-      font-size: 14px;
-      font-weight: 600;
-      color: var(--text-secondary);
-    }
-    .nav-links a:hover { color: var(--text); }
+    .nav .container { display: flex; align-items: center; gap: 12px; }
+    .nav-logo { display: flex; align-items: center; gap: 10px; font-size: 17px; font-weight: 800; letter-spacing: -.3px; color: var(--text); }
+    .nav-logo img { width: 30px; height: 30px; border-radius: 8px; }
+    .nav-links { display: flex; gap: 32px; margin-left: auto; font-size: 13.5px; font-weight: 500; }
+    .nav-links a { color: var(--text-secondary); }
+    .nav-links a:hover { color: #fff; }
     .nav-cta {
-      padding: 8px 20px;
-      background: var(--accent);
-      color: #fff;
-      border-radius: 8px;
-      font-weight: 700;
-      font-size: 13px;
-      transition: background .15s, transform .1s;
+      padding: 8px 22px; background: var(--accent); color: #fff !important;
+      border-radius: var(--radius-sm); font-weight: 600; font-size: 13px;
+      transition: all .15s; box-shadow: 0 2px 12px var(--accent-glow);
     }
-    .nav-cta:hover { background: var(--accent-hover); color: #fff; transform: translateY(-1px); }
+    .nav-cta:hover { background: var(--accent-hover); transform: translateY(-1px); box-shadow: 0 4px 20px var(--accent-glow-strong); }
 
     /* ═══ Hero ═══ */
     .hero {
-      padding: 160px 0 100px;
-      text-align: center;
-      background:
-        radial-gradient(ellipse at 30% 20%, rgba(74,144,217,.08) 0%, transparent 60%),
-        radial-gradient(ellipse at 70% 80%, rgba(155,135,245,.05) 0%, transparent 50%);
+      padding: 180px 0 120px; text-align: center; position: relative; overflow: hidden;
     }
+    .hero::before {
+      content: ''; position: absolute; top: -200px; left: 50%; transform: translateX(-50%);
+      width: 900px; height: 900px; border-radius: 50%;
+      background: radial-gradient(circle, rgba(74,144,217,.1) 0%, rgba(74,144,217,.03) 40%, transparent 70%);
+      pointer-events: none;
+    }
+    .hero::after {
+      content: ''; position: absolute; top: 60%; right: -100px;
+      width: 500px; height: 500px; border-radius: 50%;
+      background: radial-gradient(circle, rgba(155,135,245,.06) 0%, transparent 70%);
+      pointer-events: none;
+    }
+    .hero .container { position: relative; z-index: 1; }
+
     .hero-badge {
-      display: inline-flex;
-      align-items: center;
-      gap: 8px;
-      padding: 6px 16px;
-      background: rgba(74,144,217,.1);
-      border: 1px solid rgba(74,144,217,.2);
-      border-radius: 100px;
-      font-size: 12px;
-      font-weight: 700;
-      color: var(--accent);
-      letter-spacing: .3px;
-      margin-bottom: 28px;
+      display: inline-flex; align-items: center; gap: 8px;
+      padding: 7px 18px 7px 12px;
+      background: rgba(74,144,217,.08); border: 1px solid rgba(74,144,217,.18);
+      border-radius: 100px; font-size: 12.5px; font-weight: 600;
+      color: var(--accent); margin-bottom: 32px;
     }
-    .hero h1 {
-      font-size: clamp(36px, 5vw, 56px);
-      font-weight: 900;
-      line-height: 1.1;
-      letter-spacing: -1.5px;
-      max-width: 720px;
-      margin: 0 auto 20px;
+    .hero-badge-dot {
+      width: 8px; height: 8px; border-radius: 50%;
+      background: var(--green);
+      box-shadow: 0 0 8px rgba(46,204,113,.5);
+      animation: pulse-dot 2s ease-in-out infinite;
     }
-    .hero h1 span { color: var(--accent); }
-    .hero-sub {
-      font-size: 18px;
-      color: var(--text-secondary);
-      max-width: 540px;
-      margin: 0 auto 40px;
-      line-height: 1.6;
-    }
-    .hero-ctas {
-      display: flex;
-      justify-content: center;
-      gap: 14px;
-      flex-wrap: wrap;
-    }
-    .btn-primary {
-      display: inline-flex;
-      align-items: center;
-      gap: 8px;
-      padding: 14px 32px;
-      background: var(--accent);
-      color: #fff;
-      border: none;
-      border-radius: 10px;
-      font-family: var(--font);
-      font-size: 15px;
-      font-weight: 700;
-      cursor: pointer;
-      transition: background .15s, transform .1s, box-shadow .15s;
-    }
-    .btn-primary:hover {
-      background: var(--accent-hover);
-      transform: translateY(-2px);
-      box-shadow: 0 8px 32px var(--accent-glow);
-    }
-    .btn-ghost {
-      display: inline-flex;
-      align-items: center;
-      gap: 8px;
-      padding: 14px 32px;
-      background: transparent;
-      color: var(--text);
-      border: 1.5px solid rgba(255,255,255,.15);
-      border-radius: 10px;
-      font-family: var(--font);
-      font-size: 15px;
-      font-weight: 700;
-      cursor: pointer;
-      transition: background .15s, border-color .15s;
-    }
-    .btn-ghost:hover {
-      background: rgba(255,255,255,.05);
-      border-color: rgba(255,255,255,.3);
-      color: #fff;
+    @keyframes pulse-dot {
+      0%, 100% { opacity: 1; transform: scale(1); }
+      50% { opacity: .6; transform: scale(.8); }
     }
 
+    .hero h1 {
+      font-size: clamp(38px, 5.5vw, 62px); font-weight: 900;
+      line-height: 1.08; letter-spacing: -2px;
+      max-width: 740px; margin: 0 auto 22px;
+      background: linear-gradient(135deg, #fff 0%, #c8d6e8 100%);
+      -webkit-background-clip: text; -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+    .hero h1 em {
+      font-style: normal;
+      background: linear-gradient(135deg, var(--accent) 0%, var(--purple) 100%);
+      -webkit-background-clip: text; -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+    .hero-sub {
+      font-size: 17px; color: var(--text-secondary);
+      max-width: 520px; margin: 0 auto 44px; line-height: 1.7;
+    }
+    .hero-ctas { display: flex; justify-content: center; gap: 14px; flex-wrap: wrap; margin-bottom: 64px; }
+
+    .btn-primary {
+      display: inline-flex; align-items: center; gap: 8px;
+      padding: 14px 34px; background: var(--accent); color: #fff; border: none;
+      border-radius: var(--radius-sm); font-family: var(--font); font-size: 15px; font-weight: 700;
+      cursor: pointer; transition: all .2s;
+      box-shadow: 0 4px 20px var(--accent-glow);
+    }
+    .btn-primary:hover { background: var(--accent-hover); transform: translateY(-2px); box-shadow: 0 8px 40px var(--accent-glow-strong); }
+    .btn-ghost {
+      display: inline-flex; align-items: center; gap: 8px;
+      padding: 14px 34px; background: rgba(255,255,255,.04); color: var(--text);
+      border: 1.5px solid rgba(255,255,255,.1); border-radius: var(--radius-sm);
+      font-family: var(--font); font-size: 15px; font-weight: 700; cursor: pointer;
+      transition: all .2s;
+    }
+    .btn-ghost:hover { background: rgba(255,255,255,.08); border-color: rgba(255,255,255,.2); color: #fff; }
+
+    /* ═══ Floating mockup ═══ */
+    .hero-mockup {
+      max-width: 860px; margin: 0 auto; position: relative;
+      background: var(--bg-elevated); border: 1px solid var(--border);
+      border-radius: 16px; overflow: hidden;
+      box-shadow: 0 32px 80px rgba(0,0,0,.5), 0 0 0 1px rgba(255,255,255,.03) inset;
+    }
+    .mockup-bar {
+      display: flex; align-items: center; gap: 7px;
+      padding: 11px 16px; background: rgba(255,255,255,.03);
+      border-bottom: 1px solid var(--border);
+    }
+    .mockup-dot { width: 11px; height: 11px; border-radius: 50%; }
+    .mockup-body {
+      display: grid; grid-template-columns: 60px 200px 1fr;
+      min-height: 340px;
+    }
+    .mockup-rail {
+      background: rgba(255,255,255,.02); border-right: 1px solid var(--border);
+      padding: 16px 0; display: flex; flex-direction: column; align-items: center; gap: 12px;
+    }
+    .mockup-rail-icon {
+      width: 32px; height: 32px; border-radius: 8px;
+      background: rgba(255,255,255,.05); display: flex; align-items: center; justify-content: center;
+    }
+    .mockup-rail-icon.active { background: var(--accent-glow-strong); }
+    .mockup-sidebar {
+      background: rgba(255,255,255,.015); border-right: 1px solid var(--border);
+      padding: 16px 12px;
+    }
+    .mockup-sidebar-title { font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: .8px; color: var(--text-muted); margin-bottom: 10px; }
+    .mockup-channel {
+      display: flex; align-items: center; gap: 6px;
+      padding: 6px 8px; border-radius: 6px; font-size: 12px;
+      color: var(--text-secondary); margin-bottom: 2px;
+    }
+    .mockup-channel.active { background: var(--accent-glow); color: var(--accent); font-weight: 600; }
+    .mockup-channel-hash { opacity: .5; }
+    .mockup-main { padding: 20px; }
+    .mockup-msg {
+      display: flex; gap: 10px; margin-bottom: 14px;
+    }
+    .mockup-avatar {
+      width: 28px; height: 28px; border-radius: 6px; flex-shrink: 0;
+    }
+    .mockup-msg-body { flex: 1; }
+    .mockup-msg-name { font-size: 11px; font-weight: 700; margin-bottom: 2px; }
+    .mockup-msg-text { font-size: 11.5px; color: var(--text-secondary); line-height: 1.5; }
+    .mockup-msg-text code {
+      background: rgba(255,255,255,.08); padding: 1px 4px; border-radius: 3px; font-size: 10.5px;
+    }
+
+    /* ═══ Stats bar ═══ */
+    .stats {
+      padding: 40px 0 0;
+    }
+    .stats-grid {
+      display: flex; justify-content: center; gap: 48px; flex-wrap: wrap;
+    }
+    .stat { text-align: center; }
+    .stat-value { font-size: 32px; font-weight: 800; letter-spacing: -1px; color: var(--accent); }
+    .stat-label { font-size: 13px; color: var(--text-muted); font-weight: 500; margin-top: 2px; }
+
     /* ═══ Features ═══ */
-    .features {
-      padding: 80px 0;
+    .features { padding: 100px 0 80px; }
+    .section-label {
+      text-align: center; font-size: 12px; font-weight: 700; text-transform: uppercase;
+      letter-spacing: 2px; color: var(--accent); margin-bottom: 14px;
     }
-    .features-title {
-      text-align: center;
-      font-size: 32px;
-      font-weight: 800;
-      letter-spacing: -.5px;
-      margin-bottom: 12px;
+    .section-title {
+      text-align: center; font-size: 34px; font-weight: 800; letter-spacing: -.8px; margin-bottom: 14px;
     }
-    .features-sub {
-      text-align: center;
-      color: var(--text-secondary);
-      font-size: 16px;
-      margin-bottom: 52px;
+    .section-sub {
+      text-align: center; color: var(--text-secondary); font-size: 16px; margin-bottom: 56px; max-width: 500px; margin-left: auto; margin-right: auto;
     }
     .features-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-      gap: 20px;
+      display: grid; grid-template-columns: repeat(2, 1fr); gap: 18px;
     }
     .feature-card {
-      background: var(--bg-card);
-      border: 1px solid var(--border);
-      border-radius: var(--radius);
-      padding: 32px 28px;
-      transition: background .2s, border-color .2s, transform .2s;
+      background: var(--bg-card); border: 1px solid var(--border);
+      border-radius: var(--radius); padding: 34px 30px;
+      transition: all .25s cubic-bezier(.4,0,.2,1);
+      position: relative; overflow: hidden;
+    }
+    .feature-card::before {
+      content: ''; position: absolute; top: 0; left: 0; right: 0; height: 2px;
+      background: linear-gradient(90deg, transparent, var(--accent), transparent);
+      opacity: 0; transition: opacity .25s;
     }
     .feature-card:hover {
-      background: var(--bg-card-hover);
-      border-color: rgba(74,144,217,.2);
+      background: var(--bg-card-hover); border-color: var(--border-accent);
       transform: translateY(-4px);
+      box-shadow: 0 16px 48px rgba(0,0,0,.3);
     }
-    .feature-icon {
-      width: 48px;
-      height: 48px;
-      border-radius: 12px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 22px;
-      margin-bottom: 18px;
+    .feature-card:hover::before { opacity: 1; }
+
+    .feature-icon-wrap {
+      width: 52px; height: 52px; border-radius: 14px;
+      display: flex; align-items: center; justify-content: center;
+      margin-bottom: 20px; position: relative;
     }
-    .fi-blue   { background: rgba(74,144,217,.12); }
-    .fi-green  { background: rgba(46,204,113,.12); }
-    .fi-orange { background: rgba(243,156,18,.12); }
-    .fi-purple { background: rgba(155,135,245,.12); }
-    .feature-card h3 {
-      font-size: 17px;
-      font-weight: 700;
-      margin-bottom: 8px;
-    }
-    .feature-card p {
-      font-size: 14px;
-      color: var(--text-secondary);
-      line-height: 1.6;
+    .feature-icon-wrap svg { width: 24px; height: 24px; }
+    .fi-blue   { background: rgba(74,144,217,.1); color: var(--accent); }
+    .fi-orange { background: rgba(243,156,18,.1); color: var(--orange); }
+    .fi-green  { background: rgba(46,204,113,.1); color: var(--green); }
+    .fi-purple { background: rgba(155,135,245,.1); color: var(--purple); }
+    .feature-card h3 { font-size: 18px; font-weight: 700; margin-bottom: 8px; letter-spacing: -.2px; }
+    .feature-card p { font-size: 14px; color: var(--text-secondary); line-height: 1.7; }
+    .feature-tags { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 14px; }
+    .feature-tag {
+      font-size: 11px; font-weight: 600; padding: 3px 10px;
+      border-radius: 100px; background: rgba(255,255,255,.04);
+      color: var(--text-muted); border: 1px solid rgba(255,255,255,.06);
     }
 
     /* ═══ Download ═══ */
-    .download {
-      padding: 80px 0 100px;
-    }
-    .download-title {
-      text-align: center;
-      font-size: 32px;
-      font-weight: 800;
-      letter-spacing: -.5px;
-      margin-bottom: 12px;
-    }
-    .download-sub {
-      text-align: center;
-      color: var(--text-secondary);
-      font-size: 16px;
-      margin-bottom: 48px;
-    }
+    .download { padding: 80px 0 100px; }
     .download-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-      gap: 20px;
-      max-width: 820px;
-      margin: 0 auto;
+      display: grid; grid-template-columns: repeat(3, 1fr);
+      gap: 18px; max-width: 860px; margin: 0 auto;
     }
     .dl-card {
-      background: var(--bg-card);
-      border: 1px solid var(--border);
-      border-radius: var(--radius);
-      padding: 36px 28px;
-      text-align: center;
-      transition: border-color .2s, transform .2s;
+      background: var(--bg-card); border: 1px solid var(--border);
+      border-radius: var(--radius); padding: 40px 28px 32px;
+      text-align: center; transition: all .25s;
+      position: relative;
     }
-    .dl-card:hover { border-color: rgba(74,144,217,.25); transform: translateY(-3px); }
+    .dl-card:hover { border-color: var(--border-accent); transform: translateY(-3px); box-shadow: 0 12px 40px rgba(0,0,0,.3); }
     .dl-card.recommended {
       border-color: rgba(74,144,217,.3);
-      box-shadow: 0 0 40px var(--accent-glow);
+      box-shadow: 0 0 60px var(--accent-glow), 0 0 0 1px rgba(74,144,217,.1) inset;
     }
-    .dl-icon {
-      font-size: 36px;
-      margin-bottom: 16px;
+    .dl-card.recommended::after {
+      content: 'Recommande'; position: absolute; top: 12px; right: 12px;
+      font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: .5px;
+      padding: 3px 10px; border-radius: 100px;
+      background: var(--accent); color: #fff;
     }
-    .dl-card h3 {
-      font-size: 17px;
-      font-weight: 700;
-      margin-bottom: 6px;
+    .dl-icon-wrap {
+      width: 64px; height: 64px; border-radius: 16px;
+      display: flex; align-items: center; justify-content: center;
+      margin: 0 auto 20px; font-size: 28px;
     }
-    .dl-card p {
-      font-size: 13px;
-      color: var(--text-muted);
-      margin-bottom: 20px;
-    }
+    .dl-icon-wrap svg { width: 28px; height: 28px; }
+    .dli-win { background: rgba(74,144,217,.08); color: var(--accent); }
+    .dli-mac { background: rgba(155,135,245,.08); color: var(--purple); }
+    .dli-web { background: rgba(46,204,113,.08); color: var(--green); }
+    .dl-card h3 { font-size: 17px; font-weight: 700; margin-bottom: 4px; }
+    .dl-card p { font-size: 13px; color: var(--text-muted); margin-bottom: 22px; }
     .dl-btn {
-      display: inline-flex;
-      align-items: center;
-      gap: 6px;
-      padding: 11px 24px;
-      border-radius: 8px;
-      font-family: var(--font);
-      font-size: 14px;
-      font-weight: 700;
-      cursor: pointer;
-      transition: background .15s, transform .1s;
-      text-decoration: none;
+      display: inline-flex; align-items: center; gap: 7px;
+      padding: 11px 26px; border-radius: var(--radius-sm);
+      font-family: var(--font); font-size: 13.5px; font-weight: 700;
+      cursor: pointer; transition: all .15s; text-decoration: none;
     }
-    .dl-btn-primary {
-      background: var(--accent);
-      color: #fff;
-      border: none;
-    }
+    .dl-btn-primary { background: var(--accent); color: #fff; border: none; box-shadow: 0 2px 12px var(--accent-glow); }
     .dl-btn-primary:hover { background: var(--accent-hover); color: #fff; transform: translateY(-1px); }
-    .dl-btn-ghost {
-      background: transparent;
-      color: var(--text);
-      border: 1.5px solid rgba(255,255,255,.15);
-    }
-    .dl-btn-ghost:hover { background: rgba(255,255,255,.05); border-color: rgba(255,255,255,.25); color: #fff; }
+    .dl-btn-ghost { background: rgba(255,255,255,.04); color: var(--text); border: 1.5px solid rgba(255,255,255,.1); }
+    .dl-btn-ghost:hover { background: rgba(255,255,255,.08); border-color: rgba(255,255,255,.2); color: #fff; }
 
     /* ═══ Footer ═══ */
     .footer {
-      padding: 40px 0;
-      border-top: 1px solid var(--border);
-      text-align: center;
-      color: var(--text-muted);
-      font-size: 13px;
+      padding: 48px 0 40px; border-top: 1px solid var(--border);
+      text-align: center; color: var(--text-muted); font-size: 13px;
     }
-    .footer-logo {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      gap: 8px;
-      margin-bottom: 12px;
-      font-size: 15px;
-      font-weight: 700;
-      color: var(--text-secondary);
-    }
-    .footer-logo img { width: 24px; height: 24px; opacity: .7; }
-    .footer-links {
-      display: flex;
-      justify-content: center;
-      gap: 20px;
-      margin-bottom: 10px;
-    }
-    .footer-links a { color: var(--text-muted); font-size: 13px; }
+    .footer-logo { display: flex; align-items: center; justify-content: center; gap: 8px; margin-bottom: 14px; font-size: 15px; font-weight: 700; color: var(--text-secondary); }
+    .footer-logo img { width: 22px; height: 22px; opacity: .6; border-radius: 5px; }
+    .footer-links { display: flex; justify-content: center; gap: 24px; margin-bottom: 12px; }
+    .footer-links a { color: var(--text-muted); font-size: 13px; font-weight: 500; }
     .footer-links a:hover { color: var(--accent); }
 
     /* ═══ Animations ═══ */
-    .fade-in {
-      opacity: 0;
-      transform: translateY(24px);
-      transition: opacity .6s ease, transform .6s ease;
-    }
-    .fade-in.visible {
-      opacity: 1;
-      transform: translateY(0);
-    }
+    .fade-in { opacity: 0; transform: translateY(28px); transition: opacity .7s cubic-bezier(.4,0,.2,1), transform .7s cubic-bezier(.4,0,.2,1); }
+    .fade-in.visible { opacity: 1; transform: translateY(0); }
+    .fade-in:nth-child(2) { transition-delay: .08s; }
+    .fade-in:nth-child(3) { transition-delay: .16s; }
+    .fade-in:nth-child(4) { transition-delay: .24s; }
 
     /* ═══ Responsive ═══ */
-    @media (max-width: 768px) {
-      .hero { padding: 120px 0 60px; }
-      .hero h1 { font-size: 32px; }
-      .nav-links { display: none; }
+    @media (max-width: 900px) {
       .features-grid { grid-template-columns: 1fr; }
-      .download-grid { grid-template-columns: 1fr; }
+      .download-grid { grid-template-columns: 1fr; max-width: 360px; }
+      .mockup-body { grid-template-columns: 1fr; }
+      .mockup-rail, .mockup-sidebar { display: none; }
+    }
+    @media (max-width: 768px) {
+      .hero { padding: 130px 0 70px; }
+      .hero h1 { font-size: 32px; letter-spacing: -1px; }
+      .nav-links { display: none; }
+      .stats-grid { gap: 28px; }
+      .stat-value { font-size: 26px; }
     }
     @media (max-width: 480px) {
-      .hero { padding: 100px 0 50px; }
-      .hero-ctas { flex-direction: column; align-items: center; }
-      .btn-primary, .btn-ghost { width: 100%; justify-content: center; }
+      .hero { padding: 110px 0 50px; }
+      .hero-ctas { flex-direction: column; align-items: stretch; }
+      .btn-primary, .btn-ghost { justify-content: center; }
+      .hero-mockup { margin: 0 -12px; border-radius: 12px; }
     }
   </style>
 </head>
 <body>
 
-  <!-- ═══ Navigation ═══ -->
+  <!-- ═══ Nav ═══ -->
   <nav class="nav">
     <div class="container">
       <a href="/" class="nav-logo">
@@ -378,8 +357,8 @@
         CeSlack
       </a>
       <div class="nav-links">
-        <a href="#features">Fonctionnalités</a>
-        <a href="#download">Télécharger</a>
+        <a href="#features">Fonctionnalites</a>
+        <a href="#download">Telecharger</a>
       </div>
       <a href="/app" class="nav-cta">Ouvrir l'app</a>
     </div>
@@ -388,80 +367,187 @@
   <!-- ═══ Hero ═══ -->
   <section class="hero">
     <div class="container">
-      <div class="hero-badge">v2.0 — Nouvelle version disponible</div>
-      <h1>La plateforme pédagogique<br>pour votre <span>formation</span></h1>
+      <div class="hero-badge">
+        <span class="hero-badge-dot"></span>
+        v2.0 — Disponible maintenant
+      </div>
+      <h1>La plateforme qui simplifie votre <em>formation</em></h1>
       <p class="hero-sub">
-        Messagerie par promotion, suivi des devoirs, documents centralisés et collaboration en temps réel — tout en un seul endroit.
+        Messagerie, devoirs, documents et collaboration en temps reel — tout en un seul endroit, pour etudiants et enseignants.
       </p>
       <div class="hero-ctas">
         <a href="#download" class="btn-primary">
-          Télécharger gratuitement
+          <i data-lucide="download" style="width:16px;height:16px"></i>
+          Telecharger
         </a>
         <a href="/app" class="btn-ghost">
+          <i data-lucide="globe" style="width:16px;height:16px"></i>
           Version en ligne
         </a>
+      </div>
+
+      <!-- App mockup -->
+      <div class="hero-mockup fade-in">
+        <div class="mockup-bar">
+          <div class="mockup-dot" style="background:#ff5f57"></div>
+          <div class="mockup-dot" style="background:#ffbd2e"></div>
+          <div class="mockup-dot" style="background:#28c840"></div>
+        </div>
+        <div class="mockup-body">
+          <div class="mockup-rail">
+            <div class="mockup-rail-icon active"><i data-lucide="message-square" style="width:16px;height:16px;color:var(--accent)"></i></div>
+            <div class="mockup-rail-icon"><i data-lucide="book-open" style="width:16px;height:16px;color:var(--text-muted)"></i></div>
+            <div class="mockup-rail-icon"><i data-lucide="folder-open" style="width:16px;height:16px;color:var(--text-muted)"></i></div>
+            <div class="mockup-rail-icon"><i data-lucide="layout-dashboard" style="width:16px;height:16px;color:var(--text-muted)"></i></div>
+          </div>
+          <div class="mockup-sidebar">
+            <div class="mockup-sidebar-title">Canaux</div>
+            <div class="mockup-channel active"><span class="mockup-channel-hash">#</span> general</div>
+            <div class="mockup-channel"><span class="mockup-channel-hash">#</span> annonces</div>
+            <div class="mockup-channel"><span class="mockup-channel-hash">#</span> projet-web</div>
+            <div class="mockup-channel"><span class="mockup-channel-hash">#</span> algo-tp</div>
+            <div style="margin-top:16px">
+              <div class="mockup-sidebar-title">Messages directs</div>
+              <div class="mockup-channel"><span class="mockup-channel-hash">@</span> Jean Dupont</div>
+              <div class="mockup-channel"><span class="mockup-channel-hash">@</span> Marie Martin</div>
+            </div>
+          </div>
+          <div class="mockup-main">
+            <div class="mockup-msg">
+              <div class="mockup-avatar" style="background:var(--accent)"></div>
+              <div class="mockup-msg-body">
+                <div class="mockup-msg-name" style="color:var(--accent)">Prof. Fosse</div>
+                <div class="mockup-msg-text">Le rendu du projet est pour vendredi. Pensez a consulter la grille d'evaluation dans <code>#projet-web</code></div>
+              </div>
+            </div>
+            <div class="mockup-msg">
+              <div class="mockup-avatar" style="background:#e53935"></div>
+              <div class="mockup-msg-body">
+                <div class="mockup-msg-name">Jean Dupont</div>
+                <div class="mockup-msg-text">Merci ! On a une question sur le cahier des charges, c'est normal qu'il n'y ait pas de maquettes ?</div>
+              </div>
+            </div>
+            <div class="mockup-msg">
+              <div class="mockup-avatar" style="background:var(--accent)"></div>
+              <div class="mockup-msg-body">
+                <div class="mockup-msg-name" style="color:var(--accent)">Prof. Fosse</div>
+                <div class="mockup-msg-text">Les maquettes sont optionnelles pour ce livrable. Concentrez-vous sur l'architecture et le code.</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══ Stats ═══ -->
+  <section class="stats fade-in">
+    <div class="container">
+      <div class="stats-grid">
+        <div class="stat">
+          <div class="stat-value">4</div>
+          <div class="stat-label">Themes visuels</div>
+        </div>
+        <div class="stat">
+          <div class="stat-value">3</div>
+          <div class="stat-label">Plateformes</div>
+        </div>
+        <div class="stat">
+          <div class="stat-value">PWA</div>
+          <div class="stat-label">Installable sur mobile</div>
+        </div>
+        <div class="stat">
+          <div class="stat-value">&lt;1s</div>
+          <div class="stat-label">Messages en temps reel</div>
+        </div>
       </div>
     </div>
   </section>
 
   <!-- ═══ Features ═══ -->
-  <section id="features" class="features fade-in">
+  <section id="features" class="features">
     <div class="container">
-      <h2 class="features-title">Tout ce dont vous avez besoin</h2>
-      <p class="features-sub">Conçu pour les étudiants et les enseignants du CESI</p>
+      <div class="section-label fade-in">Fonctionnalites</div>
+      <h2 class="section-title fade-in">Tout ce dont vous avez besoin</h2>
+      <p class="section-sub fade-in">Concu pour les etudiants et enseignants, avec une attention particuliere a la simplicite.</p>
       <div class="features-grid">
         <div class="feature-card fade-in">
-          <div class="feature-icon fi-blue">💬</div>
-          <h3>Messagerie temps réel</h3>
-          <p>Canaux par promotion, messages directs, mentions @, formatage Markdown, emojis et indicateur de frappe.</p>
+          <div class="feature-icon-wrap fi-blue"><i data-lucide="messages-square"></i></div>
+          <h3>Messagerie temps reel</h3>
+          <p>Canaux par promotion, messages directs, mentions @utilisateur et @everyone, formatage Markdown complet avec apercu.</p>
+          <div class="feature-tags">
+            <span class="feature-tag">Ctrl+B Gras</span>
+            <span class="feature-tag">Emojis</span>
+            <span class="feature-tag">Typing</span>
+            <span class="feature-tag">#canal</span>
+          </div>
         </div>
         <div class="feature-card fade-in">
-          <div class="feature-icon fi-orange">📋</div>
+          <div class="feature-icon-wrap fi-orange"><i data-lucide="clipboard-check"></i></div>
           <h3>Suivi des devoirs</h3>
-          <p>Soumission de rendus avant deadline, grilles d'évaluation, notes, feedback et timeline par projet.</p>
+          <p>Soumission de rendus avant deadline, grilles d'evaluation multicriteres, notes, feedback, et frise chronologique.</p>
+          <div class="feature-tags">
+            <span class="feature-tag">Deadlines</span>
+            <span class="feature-tag">Rubriques</span>
+            <span class="feature-tag">AAVs</span>
+            <span class="feature-tag">Salles</span>
+          </div>
         </div>
         <div class="feature-card fade-in">
-          <div class="feature-icon fi-green">📄</div>
-          <h3>Documents centralisés</h3>
-          <p>Ressources par projet, aperçu PDF, Word et Excel intégré, téléchargement en un clic.</p>
+          <div class="feature-icon-wrap fi-green"><i data-lucide="file-text"></i></div>
+          <h3>Documents centralises</h3>
+          <p>Ressources par projet avec apercu integre PDF, Word et Excel. Telechargement en un clic, organisation par categorie.</p>
+          <div class="feature-tags">
+            <span class="feature-tag">PDF</span>
+            <span class="feature-tag">Word</span>
+            <span class="feature-tag">Excel</span>
+            <span class="feature-tag">Apercu</span>
+          </div>
         </div>
         <div class="feature-card fade-in">
-          <div class="feature-icon fi-purple">👥</div>
-          <h3>Collaboration</h3>
-          <p>Groupes de travail, frise chronologique, tableau de bord, notifications et 4 thèmes visuels.</p>
+          <div class="feature-icon-wrap fi-purple"><i data-lucide="users"></i></div>
+          <h3>Collaboration & suivi</h3>
+          <p>Groupes de travail, tableau de bord avec prochaine action, frise Gantt, timeline etudiante, et 4 themes visuels.</p>
+          <div class="feature-tags">
+            <span class="feature-tag">Dashboard</span>
+            <span class="feature-tag">Gantt</span>
+            <span class="feature-tag">Groupes</span>
+            <span class="feature-tag">Themes</span>
+          </div>
         </div>
       </div>
     </div>
   </section>
 
   <!-- ═══ Download ═══ -->
-  <section id="download" class="download fade-in">
+  <section id="download" class="download">
     <div class="container">
-      <h2 class="download-title">Disponible partout</h2>
-      <p class="download-sub">Application native ou version web — choisissez votre plateforme</p>
+      <div class="section-label fade-in">Telecharger</div>
+      <h2 class="section-title fade-in">Disponible partout</h2>
+      <p class="section-sub fade-in">Application native ou version web — choisissez votre plateforme</p>
       <div class="download-grid">
-        <div class="dl-card" id="dl-win">
-          <div class="dl-icon">🪟</div>
+        <div class="dl-card fade-in" id="dl-win">
+          <div class="dl-icon-wrap dli-win"><i data-lucide="monitor"></i></div>
           <h3>Windows</h3>
-          <p>Windows 10 ou supérieur</p>
+          <p>Windows 10 ou superieur</p>
           <a href="https://github.com/rohanfosse/slack-like-electron/releases/latest" class="dl-btn dl-btn-ghost" target="_blank" rel="noopener">
-            Télécharger .exe
+            <i data-lucide="download" style="width:14px;height:14px"></i> Telecharger .exe
           </a>
         </div>
-        <div class="dl-card" id="dl-mac">
-          <div class="dl-icon">🍎</div>
+        <div class="dl-card fade-in" id="dl-mac">
+          <div class="dl-icon-wrap dli-mac"><i data-lucide="laptop"></i></div>
           <h3>macOS</h3>
-          <p>macOS 11 Big Sur ou supérieur</p>
+          <p>macOS 11 Big Sur+</p>
           <a href="https://github.com/rohanfosse/slack-like-electron/releases/latest" class="dl-btn dl-btn-ghost" target="_blank" rel="noopener">
-            Télécharger .dmg
+            <i data-lucide="download" style="width:14px;height:14px"></i> Telecharger .dmg
           </a>
         </div>
-        <div class="dl-card" id="dl-web">
-          <div class="dl-icon">🌐</div>
+        <div class="dl-card fade-in" id="dl-web">
+          <div class="dl-icon-wrap dli-web"><i data-lucide="globe"></i></div>
           <h3>Version Web</h3>
-          <p>Aucune installation requise</p>
+          <p>Aucune installation</p>
           <a href="/app" class="dl-btn dl-btn-primary">
-            Ouvrir dans le navigateur
+            <i data-lucide="external-link" style="width:14px;height:14px"></i> Ouvrir
           </a>
         </div>
       </div>
@@ -477,36 +563,35 @@
       </div>
       <div class="footer-links">
         <a href="https://github.com/rohanfosse/slack-like-electron" target="_blank" rel="noopener">GitHub</a>
-        <a href="#features">Fonctionnalités</a>
+        <a href="#features">Fonctionnalites</a>
         <a href="/app">Se connecter</a>
       </div>
-      <p>Conçu pour le CESI — v2.0.0</p>
+      <p>Concu pour le CESI — v2.0.0</p>
     </div>
   </footer>
 
-  <!-- ═══ Scripts ═══ -->
   <script>
-    // Détection OS — mettre en avant la plateforme de l'utilisateur
-    (function() {
+    // Init Lucide icons
+    document.addEventListener('DOMContentLoaded', () => {
+      if (window.lucide) lucide.createIcons()
+    })
+
+    // OS detection
+    ;(function() {
       const ua = navigator.userAgent.toLowerCase()
       let os = 'web'
       if (ua.includes('win')) os = 'win'
       else if (ua.includes('mac')) os = 'mac'
-
       const el = document.getElementById('dl-' + os)
       if (el) el.classList.add('recommended')
     })()
 
-    // Fade-in au scroll
+    // Scroll animations
     const observer = new IntersectionObserver((entries) => {
       entries.forEach(e => {
-        if (e.isIntersecting) {
-          e.target.classList.add('visible')
-          observer.unobserve(e.target)
-        }
+        if (e.isIntersecting) { e.target.classList.add('visible'); observer.unobserve(e.target) }
       })
-    }, { threshold: 0.1 })
-
+    }, { threshold: 0.08 })
     document.querySelectorAll('.fade-in').forEach(el => observer.observe(el))
   </script>
 </body>


### PR DESCRIPTION
Design :
- Font Inter (plus moderne que Lato) avec poids 400-900
- Icones Lucide via CDN (memes icones que l'app) au lieu d'emojis
- Hero avec gradient text titre, badge pulse vert "Disponible maintenant"
- Mockup interactif de l'app (3 colonnes : rail + sidebar + messages)
- Section stats (4 themes, 3 plateformes, PWA, temps reel)
- Cards features avec barre accent top au hover + tags fonctionnalites
- Cards download avec icones Lucide (Monitor, Laptop, Globe)
- Badge "Recommande" sur la carte detectee par OS

Technique :
- Fond plus sombre (#08090c), elevation subtile des cartes
- Glow accent plus prononce sur les CTA
- Animations fade-in echelonnees (delay par nth-child)
- Mockup avec traffic lights macOS et contenu realiste
- Border-radius 16px, ombres profondes
- Responsive : mockup sidebar masquee sur mobile

https://claude.ai/code/session_01Y3nhFbJUbGrwutV7Q8drY5