### PR TITLE
refactor: complete Cursus rebranding, remove all CESI mentions from UI

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -371,9 +371,9 @@
         <span class="hero-badge-dot"></span>
         v2.0 — Disponible maintenant
       </div>
-      <h1>La plateforme qui simplifie votre <em>formation</em></h1>
+      <h1>Votre parcours de formation, <em>simplifie</em></h1>
       <p class="hero-sub">
-        Messagerie, devoirs, documents et collaboration en temps reel — tout en un seul endroit, pour etudiants et enseignants.
+        Messagerie, devoirs, documents et collaboration en temps reel — tout centralise en un seul endroit.
       </p>
       <div class="hero-ctas">
         <a href="#download" class="btn-primary">
@@ -469,7 +469,7 @@
     <div class="container">
       <div class="section-label fade-in">Fonctionnalites</div>
       <h2 class="section-title fade-in">Tout ce dont vous avez besoin</h2>
-      <p class="section-sub fade-in">Concu pour les etudiants et enseignants, avec une attention particuliere a la simplicite.</p>
+      <p class="section-sub fade-in">Concu pour etudiants et enseignants, avec une attention particuliere a la simplicite.</p>
       <div class="features-grid">
         <div class="feature-card fade-in">
           <div class="feature-icon-wrap fi-blue"><i data-lucide="messages-square"></i></div>
@@ -566,7 +566,7 @@
         <a href="#features">Fonctionnalites</a>
         <a href="/app">Se connecter</a>
       </div>
-      <p>Concu pour le CESI — v2.0.0</p>
+      <p>Concu par <a href="https://github.com/rohanfosse" target="_blank" rel="noopener">Rohan Fosse</a> — v2.0.0</p>
     </div>
   </footer>
 

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
     "electron",
     "vue",
     "education",
-    "cesi"
+    "cursus"
   ],
-  "author": "Rohan Fossé <rohan.fosse@cesi.fr>",
+  "author": "Rohan Fossé",
   "license": "MIT",
   "dependencies": {
     "bcryptjs": "^3.0.3",
@@ -77,7 +77,7 @@
     "vue-tsc": "^2.2.12"
   },
   "build": {
-    "appId": "fr.cesi.cursus",
+    "appId": "dev.rohanfosse.cursus",
     "productName": "Cursus",
     "directories": {
       "output": "dist"

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -22,7 +22,7 @@
           object-src  'none';
           base-uri    'none';
         " />
-  <title>CESI Cours</title>
+  <title>Cursus</title>
   <link rel="stylesheet" href="css/base.css" />
   <link rel="stylesheet" href="css/layout.css" />
   <link rel="stylesheet" href="css/components.css" />
@@ -37,8 +37,8 @@
   <!-- Zone gauche : logo -->
   <div class="top-bar-left">
     <div class="top-logo">
-      <div class="logo-mark">CC</div>
-      <span class="logo-text">CESI Cours</span>
+      <div class="logo-mark">Cu</div>
+      <span class="logo-text">Cursus</span>
     </div>
   </div>
 

--- a/renderer/js/views/login.js
+++ b/renderer/js/views/login.js
@@ -43,8 +43,8 @@ function _showEmailForm(onLogin, prefillEmail = '') {
   overlay.innerHTML = `
     <div id="login-panel">
       <div id="login-logo">
-        <div class="logo-mark">CC</div>
-        <span class="logo-text">CESI Cours</span>
+        <div class="logo-mark">Cu</div>
+        <span class="logo-text">Cursus</span>
       </div>
       <h2 id="login-title">Connexion</h2>
       <p id="login-subtitle">Entrez vos identifiants pour continuer</p>
@@ -216,11 +216,11 @@ async function _showRegisterForm(onLogin) {
   overlay.innerHTML = `
     <div id="login-panel" style="max-width:480px;">
       <div id="login-logo">
-        <div class="logo-mark">CC</div>
-        <span class="logo-text">CESI Cours</span>
+        <div class="logo-mark">Cu</div>
+        <span class="logo-text">Cursus</span>
       </div>
       <h2 id="login-title">Nouveau compte étudiant</h2>
-      <p id="login-subtitle">Seules les adresses @viacesi.fr sont acceptées</p>
+      <p id="login-subtitle">Utilisez votre adresse @viacesi.fr</p>
 
       <form id="register-form" style="width:100%;display:flex;flex-direction:column;gap:12px;margin-top:8px;">
 
@@ -246,7 +246,7 @@ async function _showRegisterForm(onLogin) {
         </div>
 
         <div class="form-group">
-          <label class="form-label">Adresse email CESI</label>
+          <label class="form-label">Adresse email</label>
           <input type="email" id="reg-email" class="form-input" placeholder="prenom.nom@viacesi.fr" required autocomplete="off"/>
           <span id="reg-email-error" class="field-error"></span>
         </div>

--- a/src/ipc.js
+++ b/src/ipc.js
@@ -114,7 +114,7 @@ function register() {
       const { BrowserWindow } = require('electron');
       const win = new BrowserWindow({
         width: 960, height: 780,
-        title: 'Visualisation — CESI Classroom',
+        title: 'Visualisation — Cursus',
         backgroundColor: '#111214',
         webPreferences: { nodeIntegration: false, contextIsolation: true },
       });

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -30,7 +30,7 @@ function createWindow(): void {
     height: 800,
     minWidth: 960,
     minHeight: 640,
-    title: 'CESIA',
+    title: 'Cursus',
     icon: join(__dirname, '../../resources/icon.png'),
     backgroundColor: '#111214',
     titleBarStyle: 'hidden',

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -205,7 +205,7 @@
         <div class="privacy-icon">🔒</div>
         <h3 class="privacy-title">Vos données &amp; confidentialité</h3>
         <div class="privacy-body">
-          <p>CESIA stocke localement les données suivantes :</p>
+          <p>Cursus stocke localement les données suivantes :</p>
           <ul>
             <li><strong>Messages</strong> — conservés dans la base de données locale de l'établissement.</li>
             <li><strong>Rendus &amp; notes</strong> — accessibles à votre responsable pédagogique.</li>

--- a/src/renderer/src/components/auth/LoginOverlay.vue
+++ b/src/renderer/src/components/auth/LoginOverlay.vue
@@ -191,7 +191,7 @@
         <!-- ── Inscription ── -->
         <div v-else key="register" class="auth-card auth-card-wide">
           <h2 class="auth-card-title">Créer un compte</h2>
-          <p class="auth-card-sub">Réservé aux adresses <strong>@viacesi.fr</strong></p>
+          <p class="auth-card-sub">Utilisez votre adresse <strong>@viacesi.fr</strong></p>
 
           <form class="auth-form" @submit.prevent="handleRegister">
             <!-- Avatar -->
@@ -226,7 +226,7 @@
             </div>
 
             <div class="auth-field">
-              <label class="auth-label">Email CESI</label>
+              <label class="auth-label">Adresse email</label>
               <input v-model="regEmail" type="email" class="auth-input" placeholder="prenom.nom@viacesi.fr" required />
               <Transition name="err-pop">
                 <span v-if="regEmailErr" class="auth-field-error">{{ regEmailErr }}</span>

--- a/src/renderer/src/components/layout/NavRail.vue
+++ b/src/renderer/src/components/layout/NavRail.vue
@@ -74,7 +74,7 @@
       <img
         :src="logoUrl"
         class="nav-logo-img"
-        alt="CESIA"
+        alt="Cursus"
         :style="appStore.isStaff ? { cursor: 'pointer' } : {}"
         :title="appStore.isStaff ? 'Tableau de bord' : undefined"
         @click="appStore.isStaff && router.push('/dashboard')"

--- a/src/renderer/src/components/modals/CmdPalette.vue
+++ b/src/renderer/src/components/modals/CmdPalette.vue
@@ -228,7 +228,7 @@
         <div class="cmd-palette-box">
           <!-- Barre de recherche -->
           <div class="cmd-search-bar">
-            <img :src="logoUrl" class="cmd-logo" alt="CESIA" />
+            <img :src="logoUrl" class="cmd-logo" alt="Cursus" />
             <Search :size="15" class="cmd-search-icon" />
             <input
               ref="inputEl"

--- a/src/renderer/src/components/modals/SettingsModal.vue
+++ b/src/renderer/src/components/modals/SettingsModal.vue
@@ -340,11 +340,11 @@
             <h4 class="stg-group-title">Application</h4>
             <div class="stg-info-row">
               <span class="stg-info-label">Nom</span>
-              <span class="stg-info-value">CESI Cours</span>
+              <span class="stg-info-value">Cursus</span>
             </div>
             <div class="stg-info-row">
               <span class="stg-info-label">Version</span>
-              <span class="stg-info-value">1.0.0</span>
+              <span class="stg-info-value">2.0.0</span>
             </div>
             <div class="stg-info-row">
               <span class="stg-info-label">Plateforme</span>
@@ -355,9 +355,9 @@
           <div class="stg-group">
             <h4 class="stg-group-title">Description</h4>
             <p class="stg-about-text">
-              Plateforme pédagogique pour la gestion des cours, travaux et documents
-              entre enseignants et étudiants CESI. Messagerie en temps réel, suivi
-              des rendus, gestion des ressources et planification Gantt.
+              Plateforme pédagogique open-source par Rohan Fossé. Messagerie en temps
+              réel, suivi des devoirs et rendus, gestion des documents et planification
+              Gantt — tout en un seul endroit.
             </p>
           </div>
         </section>


### PR DESCRIPTION
- Landing: new hero "Votre parcours de formation, simplifie"
- Landing footer: "Concu par Rohan Fosse" instead of "Concu pour le CESI"
- Login: tagline "Suivez votre parcours de formation"
- Login: "Adresse email" label instead of "Email CESI"
- Settings: app name Cursus, description credits Rohan Fosse
- Settings: version bumped to 2.0.0
- Privacy notice: "Cursus stocke..." instead of "CESIA stocke..."
- Window title: "Cursus" instead of "CESIA"
- Legacy renderer: "Cursus" instead of "CESI Cours"
- AppId: dev.rohanfosse.cursus instead of fr.cesi.cursus
- package.json: author simplified, keyword cesi -> cursus

Note: @viacesi.fr email domain validation and seed data kept as-is (functional, not branding).

https://claude.ai/code/session_01Y3nhFbJUbGrwutV7Q8drY5