### PR TITLE
Optimiser le rafraîchissement de la messagerie

### DIFF
--- a/server/db/models/messages.js
+++ b/server/db/models/messages.js
@@ -1,17 +1,29 @@
 const { getDb } = require('../connection');
 
 const PAGE_SIZE = 50;
+const MESSAGE_SELECT = `
+  SELECT m.*,
+         m.pinned AS is_pinned,
+         COALESCE(s.avatar_initials, substr(upper(m.author_name), 1, 2)) AS author_initials,
+         COALESCE(s.photo_data, t.photo_data) AS author_photo
+  FROM messages m
+  LEFT JOIN students s ON s.name = m.author_name
+  LEFT JOIN teachers t ON t.name = m.author_name
+`;
 
 function getChannelMessages(channelId) {
   return getDb().prepare(
-    `SELECT m.*,
-           COALESCE(s.avatar_initials, substr(upper(m.author_name), 1, 2)) AS author_initials,
-           COALESCE(s.photo_data, t.photo_data) AS author_photo
-    FROM messages m
-    LEFT JOIN students s ON s.name = m.author_name
-    LEFT JOIN teachers t ON t.name = m.author_name
-    WHERE m.channel_id = ? ORDER BY m.created_at ASC`
+    `${MESSAGE_SELECT}
+     WHERE m.channel_id = ?
+     ORDER BY m.created_at ASC`
   ).all(channelId);
+}
+
+function getMessageById(messageId) {
+  return getDb().prepare(
+    `${MESSAGE_SELECT}
+     WHERE m.id = ?`
+  ).get(messageId) ?? null;
 }
 
 /**
@@ -22,32 +34,25 @@ function getChannelMessages(channelId) {
 function getChannelMessagesPage(channelId, beforeId) {
   if (beforeId) {
     return getDb().prepare(
-      `SELECT m.*, COALESCE(s.avatar_initials, substr(upper(m.author_name), 1, 2)) AS author_initials,
-           COALESCE(s.photo_data, t.photo_data) AS author_photo
-    FROM messages m
-    LEFT JOIN students s ON s.name = m.author_name
-    LEFT JOIN teachers t ON t.name = m.author_name
-WHERE m.channel_id = ? AND m.id < ? ORDER BY m.id DESC LIMIT ?`
+      `${MESSAGE_SELECT}
+       WHERE m.channel_id = ? AND m.id < ?
+       ORDER BY m.id DESC
+       LIMIT ?`
     ).all(channelId, beforeId, PAGE_SIZE);
   }
   return getDb().prepare(
-    `SELECT m.*, COALESCE(s.avatar_initials, substr(upper(m.author_name), 1, 2)) AS author_initials,
-           COALESCE(s.photo_data, t.photo_data) AS author_photo
-    FROM messages m
-    LEFT JOIN students s ON s.name = m.author_name
-    LEFT JOIN teachers t ON t.name = m.author_name
-WHERE m.channel_id = ? ORDER BY m.id DESC LIMIT ?`
+    `${MESSAGE_SELECT}
+     WHERE m.channel_id = ?
+     ORDER BY m.id DESC
+     LIMIT ?`
   ).all(channelId, PAGE_SIZE);
 }
 
 function getDmMessages(studentId) {
   return getDb().prepare(
-    `SELECT m.*, COALESCE(s.avatar_initials, substr(upper(m.author_name), 1, 2)) AS author_initials,
-           COALESCE(s.photo_data, t.photo_data) AS author_photo
-    FROM messages m
-    LEFT JOIN students s ON s.name = m.author_name
-    LEFT JOIN teachers t ON t.name = m.author_name
-WHERE m.dm_student_id = ? ORDER BY m.created_at ASC`
+    `${MESSAGE_SELECT}
+     WHERE m.dm_student_id = ?
+     ORDER BY m.created_at ASC`
   ).all(studentId);
 }
 
@@ -80,20 +85,20 @@ function getDmMessagesPage(studentId, beforeId, peerStudentId) {
 
       if (beforeId) {
         return getDb().prepare(
-          `SELECT m.*, COALESCE(s.avatar_initials, substr(upper(m.author_name), 1, 2)) AS author_initials, COALESCE(s.photo_data, t.photo_data) AS author_photo
-           FROM messages m LEFT JOIN students s ON s.name = m.author_name LEFT JOIN teachers t ON t.name = m.author_name
+          `${MESSAGE_SELECT}
            WHERE m.dm_student_id = ?
              AND m.author_name IN (?, ?)
              AND m.id < ?
-           ORDER BY m.id DESC LIMIT ?`
+           ORDER BY m.id DESC
+           LIMIT ?`
         ).all(boxId, selfName, peerName, beforeId, PAGE_SIZE)
       }
       return getDb().prepare(
-        `SELECT m.*, COALESCE(s.avatar_initials, substr(upper(m.author_name), 1, 2)) AS author_initials, COALESCE(s.photo_data, t.photo_data) AS author_photo
-         FROM messages m LEFT JOIN students s ON s.name = m.author_name LEFT JOIN teachers t ON t.name = m.author_name
+        `${MESSAGE_SELECT}
          WHERE m.dm_student_id = ?
            AND m.author_name IN (?, ?)
-         ORDER BY m.id DESC LIMIT ?`
+         ORDER BY m.id DESC
+         LIMIT ?`
       ).all(boxId, selfName, peerName, PAGE_SIZE)
     }
   }
@@ -101,29 +106,26 @@ function getDmMessagesPage(studentId, beforeId, peerStudentId) {
   // Fallback : boîte unique (comportement existant)
   if (beforeId) {
     return getDb().prepare(
-      `SELECT m.*, COALESCE(s.avatar_initials, substr(upper(m.author_name), 1, 2)) AS author_initials,
-           COALESCE(s.photo_data, t.photo_data) AS author_photo
-    FROM messages m
-    LEFT JOIN students s ON s.name = m.author_name
-    LEFT JOIN teachers t ON t.name = m.author_name
-WHERE m.dm_student_id = ? AND m.id < ? ORDER BY m.id DESC LIMIT ?`
+      `${MESSAGE_SELECT}
+       WHERE m.dm_student_id = ? AND m.id < ?
+       ORDER BY m.id DESC
+       LIMIT ?`
     ).all(studentId, beforeId, PAGE_SIZE);
   }
   return getDb().prepare(
-    `SELECT m.*, COALESCE(s.avatar_initials, substr(upper(m.author_name), 1, 2)) AS author_initials,
-           COALESCE(s.photo_data, t.photo_data) AS author_photo
-    FROM messages m
-    LEFT JOIN students s ON s.name = m.author_name
-    LEFT JOIN teachers t ON t.name = m.author_name
-WHERE m.dm_student_id = ? ORDER BY m.id DESC LIMIT ?`
+    `${MESSAGE_SELECT}
+     WHERE m.dm_student_id = ?
+     ORDER BY m.id DESC
+     LIMIT ?`
   ).all(studentId, PAGE_SIZE);
 }
 
 function searchMessages(channelId, query) {
   return getDb().prepare(`
-    SELECT * FROM messages
-    WHERE channel_id = ? AND content LIKE '%' || ? || '%'
-    ORDER BY created_at ASC LIMIT 200
+    ${MESSAGE_SELECT}
+    WHERE m.channel_id = ? AND m.content LIKE '%' || ? || '%'
+    ORDER BY m.created_at ASC
+    LIMIT 200
   `).all(channelId, query);
 }
 
@@ -142,13 +144,10 @@ function searchDmMessages(studentId, query, peerId) {
   }
 
   return getDb().prepare(`
-    SELECT m.*, COALESCE(s.avatar_initials, substr(upper(m.author_name), 1, 2)) AS author_initials,
-           COALESCE(s.photo_data, t.photo_data) AS author_photo
-    FROM messages m
-    LEFT JOIN students s ON s.name = m.author_name
-    LEFT JOIN teachers t ON t.name = m.author_name
+    ${MESSAGE_SELECT}
     WHERE ${where}
-    ORDER BY m.created_at ASC LIMIT 200
+    ORDER BY m.created_at ASC
+    LIMIT 200
   `).all(...params);
 }
 
@@ -280,6 +279,7 @@ function getRecentDmContacts(studentId, limit = 15) {
 }
 
 module.exports = {
+  getMessageById,
   getChannelMessages, getChannelMessagesPage,
   getDmMessages, getDmMessagesPage,
   searchMessages, searchDmMessages, searchAllMessages, sendMessage,

--- a/server/routes/messages.js
+++ b/server/routes/messages.js
@@ -86,6 +86,10 @@ router.post('/', validate(sendMessageSchema), (req, res) => {
     }
 
     const result  = queries.sendMessage(payload)
+    const message = queries.getMessageById(Number(result.lastInsertRowid))
+    if (!message) {
+      throw new Error('Le message a été inséré mais n’a pas pu être relu.')
+    }
 
     // ── Parsing des mentions ─────────────────────────────────────────────────
     const rawContent      = payload.content ?? ''
@@ -124,7 +128,7 @@ router.post('/', validate(sendMessageSchema), (req, res) => {
       }
     }
 
-    res.json({ ok: true, data: result })
+    res.json({ ok: true, data: message })
   } catch (err) {
     res.status(400).json({ ok: false, error: err.message })
   }

--- a/src/main/ipc/messages.js
+++ b/src/main/ipc/messages.js
@@ -24,6 +24,10 @@ function register() {
       }
       payload = parsed.data
       const result = queries.sendMessage(payload)
+      const message = queries.getMessageById(Number(result.lastInsertRowid))
+      if (!message) {
+        throw new Error('Le message a été inséré mais n’a pas pu être relu.')
+      }
 
       // Parsing des mentions
       const rawContent      = payload.content ?? ''
@@ -49,7 +53,7 @@ function register() {
       for (const win of BrowserWindow.getAllWindows()) {
         if (!win.isDestroyed()) win.webContents.send('msg:new', push)
       }
-      return { ok: true, data: result }
+      return { ok: true, data: message }
     } catch (err) {
       console.error('[IPC db:sendMessage]', err.message)
       return { ok: false, error: err.message }

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -38,7 +38,7 @@ declare global {
       searchMessages(channelId: number, q: string): Promise<IpcResponse<Message[]>>
       searchDmMessages(studentId: number, q: string, peer?: number): Promise<IpcResponse<Message[]>>
       searchAllMessages(args: { promoId: number | null; query: string; limit?: number }): Promise<IpcResponse<{ id: number; content: string; author_name: string; created_at: string; channel_id: number; channel_name: string; promo_id: number }[]>>
-      sendMessage(payload: SendMessagePayload): Promise<IpcResponse<{ id: number }>>
+      sendMessage(payload: SendMessagePayload): Promise<IpcResponse<Message>>
       updateReactions(msgId: number, reactionsJson: string): Promise<IpcResponse<number>>
 
       // Travaux / Devoirs
@@ -137,7 +137,7 @@ declare global {
 
       // Messages épinglés
       getPinnedMessages(channelId: number): Promise<IpcResponse<Message[]>>
-      togglePinMessage(payload: { messageId: number; pinned: boolean }): Promise<IpcResponse<null>>
+      togglePinMessage(payload: { messageId: number; pinned: boolean }): Promise<IpcResponse<number>>
       deleteMessage(id: number): Promise<IpcResponse<number>>
       reportMessage(messageId: number, reason: string): Promise<IpcResponse<null>>
       getTeacherReminders(): Promise<IpcResponse<{ id: number; promo_tag: string; date: string; title: string; description: string; bloc: string | null; done: number }[]>>

--- a/src/renderer/src/stores/messages.ts
+++ b/src/renderer/src/stores/messages.ts
@@ -79,6 +79,45 @@ export const useMessagesStore = defineStore('messages', () => {
     return null
   }
 
+  function markLatestAsRead(messageId: number) {
+    const lrKey = _lrKey()
+    if (lrKey) localStorage.setItem(lrKey, String(messageId))
+  }
+
+  function upsertMessage(message: Message) {
+    const existingIndex = messages.value.findIndex((item) => item.id === message.id)
+    if (existingIndex >= 0) {
+      messages.value = messages.value.map((item) => item.id === message.id ? message : item)
+    } else {
+      messages.value = [...messages.value, message]
+    }
+    initReactions(message.id, message.reactions)
+    firstUnreadId.value = null
+    markLatestAsRead(message.id)
+  }
+
+  function setPinnedState(messageId: number, isPinned: boolean) {
+    messages.value = messages.value.map((message) =>
+      message.id === messageId
+        ? { ...message, is_pinned: isPinned ? 1 : 0 }
+        : message,
+    )
+  }
+
+  function syncPinnedCache(messageId: number, isPinned: boolean) {
+    const message = messages.value.find((item) => item.id === messageId)
+    if (!message) return
+
+    const nextPinned = isPinned
+      ? [message, ...pinned.value.filter((item) => item.id !== messageId)]
+      : pinned.value.filter((item) => item.id !== messageId)
+
+    pinned.value = nextPinned
+      .slice()
+      .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
+      .slice(0, 5)
+  }
+
   // ── Fetch initial ──────────────────────────────────────────────────────────
   async function fetchMessages() {
     loading.value    = true
@@ -118,9 +157,7 @@ export const useMessagesStore = defineStore('messages', () => {
         firstUnreadId.value = first?.id ?? null
       }
 
-      if (lrKey && fetched.length) {
-        localStorage.setItem(lrKey, String(fetched[fetched.length - 1].id))
-      }
+      if (lrKey && fetched.length) markLatestAsRead(fetched[fetched.length - 1].id)
     } finally {
       loading.value = false
     }
@@ -167,7 +204,7 @@ export const useMessagesStore = defineStore('messages', () => {
       return false
     }
     const quote = quotedMessage.value
-    const result = await api(
+    const result = await api<Message>(
       () => window.api.sendMessage({
         channelId:   appStore.activeChannelId   ?? undefined,
         dmStudentId: appStore.activeDmStudentId ?? undefined,
@@ -188,16 +225,21 @@ export const useMessagesStore = defineStore('messages', () => {
     }
     sendError.value = false
     clearQuote()
-    await fetchMessages()
+    if (searchTerm.value) {
+      await fetchMessages()
+    } else {
+      upsertMessage(result)
+    }
     return true
   }
 
   // ── Épinglage ──────────────────────────────────────────────────────────────
   async function togglePin(messageId: number, pinned_: boolean) {
     if (!appStore.activeChannelId) return
-    await api(() => window.api.togglePinMessage({ messageId, pinned: pinned_ }), 'pin')
-    await fetchPinned(appStore.activeChannelId)
-    await fetchMessages()
+    const updated = await api<number>(() => window.api.togglePinMessage({ messageId, pinned: pinned_ }), 'pin')
+    if (updated === null) return
+    setPinnedState(messageId, pinned_)
+    syncPinnedCache(messageId, pinned_)
   }
 
   // ── Réactions ──────────────────────────────────────────────────────────────

--- a/tests/backend/db/messages.test.js
+++ b/tests/backend/db/messages.test.js
@@ -29,6 +29,17 @@ describe('messages model', () => {
     expect(msgs[0].author_name).toBe('Jean Dupont')
   })
 
+  it('getMessageById returns enriched message data', () => {
+    const msgs = queries.getChannelMessages(1)
+    const message = queries.getMessageById(msgs[0].id)
+    expect(message).toMatchObject({
+      id: msgs[0].id,
+      author_name: 'Jean Dupont',
+      author_initials: 'JD',
+      is_pinned: 0,
+    })
+  })
+
   it('editMessage updates content and sets edited flag', () => {
     const msgs = queries.getChannelMessages(1)
     const msgId = msgs[0].id
@@ -56,6 +67,7 @@ describe('messages model', () => {
     const pinned = queries.getPinnedMessages(1)
     expect(pinned.length).toBe(1)
     expect(pinned[0].id).toBe(msgId)
+    expect(queries.getMessageById(msgId).is_pinned).toBe(1)
   })
 
   it('togglePinMessage unpins a message', () => {

--- a/tests/frontend/stores/messages.test.ts
+++ b/tests/frontend/stores/messages.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { useAppStore } from '@/stores/app'
+import { useMessagesStore } from '@/stores/messages'
+import type { Message, User } from '@/types'
+
+vi.mock('@/composables/useToast', () => ({
+  useToast: () => ({ showToast: vi.fn() }),
+}))
+
+const sendMessageMock = vi.fn()
+const togglePinMessageMock = vi.fn()
+const getChannelMessagesPageMock = vi.fn()
+const getDmMessagesPageMock = vi.fn()
+const searchMessagesMock = vi.fn()
+const searchDmMessagesMock = vi.fn()
+const getPinnedMessagesMock = vi.fn()
+
+function makeUser(): User {
+  return {
+    id: 1,
+    name: 'Jean Dupont',
+    avatar_initials: 'JD',
+    photo_data: null,
+    type: 'student',
+    promo_id: 7,
+    promo_name: 'Promo Test',
+    must_change_password: 0,
+  }
+}
+
+function makeMessage(overrides: Partial<Message> = {}): Message {
+  return {
+    id: 1,
+    channel_id: 42,
+    dm_student_id: null,
+    author_id: 1,
+    author_name: 'Jean Dupont',
+    author_type: 'student',
+    author_initials: 'JD',
+    author_photo: null,
+    content: 'Bonjour',
+    created_at: '2026-03-21T10:00:00.000Z',
+    reactions: null,
+    is_pinned: 0,
+    edited: 0,
+    ...overrides,
+  }
+}
+
+describe('messages store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorage.clear()
+    sendMessageMock.mockReset()
+    togglePinMessageMock.mockReset()
+    getChannelMessagesPageMock.mockReset()
+    getDmMessagesPageMock.mockReset()
+    searchMessagesMock.mockReset()
+    searchDmMessagesMock.mockReset()
+    getPinnedMessagesMock.mockReset()
+
+    ;(window as unknown as { api: Record<string, unknown> }).api = {
+      sendMessage: sendMessageMock,
+      togglePinMessage: togglePinMessageMock,
+      getChannelMessagesPage: getChannelMessagesPageMock,
+      getDmMessagesPage: getDmMessagesPageMock,
+      searchMessages: searchMessagesMock,
+      searchDmMessages: searchDmMessagesMock,
+      getPinnedMessages: getPinnedMessagesMock,
+    }
+
+    const appStore = useAppStore()
+    appStore.currentUser = makeUser()
+    appStore.activeChannelId = 42
+    appStore.activeChannelName = 'general'
+    appStore.activePromoId = 7
+  })
+
+  it('appends the inserted message after send without reloading the page', async () => {
+    const store = useMessagesStore()
+    const inserted = makeMessage({ id: 99, content: 'Message local' })
+
+    sendMessageMock.mockResolvedValue({ ok: true, data: inserted })
+
+    const ok = await store.sendMessage('Message local')
+
+    expect(ok).toBe(true)
+    expect(store.messages).toEqual([inserted])
+    expect(getChannelMessagesPageMock).not.toHaveBeenCalled()
+    expect(localStorage.getItem('lastRead:ch:42')).toBe('99')
+  })
+
+  it('updates pin state locally without refetching messages or pinned items', async () => {
+    const store = useMessagesStore()
+    const message = makeMessage({ id: 10, created_at: '2026-03-21T11:00:00.000Z' })
+    const olderPinned = makeMessage({
+      id: 3,
+      content: 'Ancien pin',
+      created_at: '2026-03-21T09:00:00.000Z',
+      is_pinned: 1,
+    })
+
+    store.messages = [message]
+    store.pinned = [olderPinned]
+
+    togglePinMessageMock.mockResolvedValue({ ok: true, data: 1 })
+
+    await store.togglePin(10, true)
+
+    expect(store.messages[0].is_pinned).toBe(1)
+    expect(store.pinned.map((item) => item.id)).toEqual([10, 3])
+    expect(getChannelMessagesPageMock).not.toHaveBeenCalled()
+    expect(getPinnedMessagesMock).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Résumé
- renvoyer le message complet après insertion côté messagerie
- mettre à jour localement le store après envoi et épinglage au lieu de recharger toute la page
- ajouter des tests ciblés sur ce flux

## Vérifications
- `npm.cmd run typecheck`
- `npm.cmd run test -- --project frontend tests/frontend/stores/messages.test.ts`
- les tests backend sont bloqués localement car `better-sqlite3` n'est pas compilé dans cet environnement