### PR TITLE
Redesign admin page with lighter, welcoming theme and fix navigation

### DIFF
--- a/server/public/admin/index.html
+++ b/server/public/admin/index.html
@@ -42,10 +42,10 @@
       <a href="/" class="back-link">&larr; Retour au site</a>
       <h1>Console d'administration</h1>
     </div>
-    <div style="display:flex;align-items:center;gap:1rem">
+    <div style="display:flex;align-items:center;gap:.5rem">
       <div class="status"><div id="status-dot" class="dot"></div><span id="status-text">Connect&eacute;</span></div>
       <button class="refresh-btn" onclick="refreshActiveTab()">Rafra&icirc;chir</button>
-      <button class="refresh-btn" style="background:rgba(231,76,60,.15);color:#e74c3c;border-color:rgba(231,76,60,.3)" onclick="logout()">D&eacute;connexion</button>
+      <button class="refresh-btn" style="color:#ef4444;border-color:rgba(239,68,68,.2)" onclick="logout()">D&eacute;connexion</button>
     </div>
   </div>
 
@@ -54,35 +54,24 @@
     La plateforme est en <strong>mode lecture seule</strong>. Les &eacute;tudiants ne peuvent pas poster de messages ni soumettre de d&eacute;p&ocirc;ts.
   </div>
 
-  <!-- Tab bar (grouped) -->
+  <!-- Tab bar (flat, simple) -->
   <div class="tab-bar">
-    <div class="tab-group">
-      <span class="tab-group-label">Monitoring</span>
-      <button class="tab-btn active" data-tab="serveur" onclick="switchTab('serveur')">Serveur</button>
-      <button class="tab-btn" data-tab="stats" onclick="switchTab('stats')">Statistiques</button>
-    </div>
-    <div class="tab-group">
-      <span class="tab-group-label">Gestion</span>
-      <button class="tab-btn" data-tab="users" onclick="switchTab('users')">Utilisateurs</button>
-      <button class="tab-btn" data-tab="moderation" onclick="switchTab('moderation')">Mod&eacute;ration <span id="reports-badge" class="tab-badge" style="display:none"></span></button>
-      <button class="tab-btn" data-tab="scheduled" onclick="switchTab('scheduled')">Annonces</button>
-    </div>
-    <div class="tab-group">
-      <span class="tab-group-label">S&eacute;curit&eacute;</span>
-      <button class="tab-btn" data-tab="audit" onclick="switchTab('audit')">Audit</button>
-      <button class="tab-btn" data-tab="security" onclick="switchTab('security')">S&eacute;curit&eacute;</button>
-      <button class="tab-btn" data-tab="sessions" onclick="switchTab('sessions')">Sessions</button>
-    </div>
-    <div class="tab-group">
-      <span class="tab-group-label">Op&eacute;rations</span>
-      <button class="tab-btn" data-tab="deploy" onclick="switchTab('deploy')">D&eacute;ploiement</button>
-      <button class="tab-btn" data-tab="import" onclick="switchTab('import')">Import</button>
-      <button class="tab-btn" data-tab="maintenance" onclick="switchTab('maintenance')">Maintenance</button>
-    </div>
-    <div class="tab-group">
-      <span class="tab-group-label">Support</span>
-      <button class="tab-btn" data-tab="feedback" onclick="switchTab('feedback')">Feedback <span id="feedback-badge" class="tab-badge" style="display:none"></span></button>
-    </div>
+    <button class="tab-btn active" data-tab="serveur" onclick="switchTab('serveur')">Serveur</button>
+    <button class="tab-btn" data-tab="stats" onclick="switchTab('stats')">Statistiques</button>
+    <div class="tab-separator"></div>
+    <button class="tab-btn" data-tab="users" onclick="switchTab('users')">Utilisateurs</button>
+    <button class="tab-btn" data-tab="moderation" onclick="switchTab('moderation')">Mod&eacute;ration <span id="reports-badge" class="tab-badge" style="display:none"></span></button>
+    <button class="tab-btn" data-tab="scheduled" onclick="switchTab('scheduled')">Annonces</button>
+    <div class="tab-separator"></div>
+    <button class="tab-btn" data-tab="audit" onclick="switchTab('audit')">Audit</button>
+    <button class="tab-btn" data-tab="security" onclick="switchTab('security')">S&eacute;curit&eacute;</button>
+    <button class="tab-btn" data-tab="sessions" onclick="switchTab('sessions')">Sessions</button>
+    <div class="tab-separator"></div>
+    <button class="tab-btn" data-tab="deploy" onclick="switchTab('deploy')">D&eacute;ploiement</button>
+    <button class="tab-btn" data-tab="import" onclick="switchTab('import')">Import</button>
+    <button class="tab-btn" data-tab="maintenance" onclick="switchTab('maintenance')">Maintenance</button>
+    <div class="tab-separator"></div>
+    <button class="tab-btn" data-tab="feedback" onclick="switchTab('feedback')">Feedback <span id="feedback-badge" class="tab-badge" style="display:none"></span></button>
   </div>
 
   <!-- Tab panels -->

--- a/server/public/admin/modules/deploy.js
+++ b/server/public/admin/modules/deploy.js
@@ -1,4 +1,4 @@
-import { apiFetch, escHtml } from '../app.js'
+import { apiFetch, escHtml, toast, confirmAction } from '../app.js'
 
 export async function loadDeploy() {
   const el = document.getElementById('deploy-content')
@@ -130,7 +130,8 @@ export async function gitPull() {
 }
 
 export async function dockerRebuild() {
-  if (!confirm('Rebuilder l\'image Docker et relancer le container ?')) return
+  const ok = await confirmAction('Rebuilder l\'image Docker et relancer le container ?', { title: 'Docker Rebuild', confirmText: 'Rebuild' })
+  if (!ok) return
   const out = document.getElementById('docker-output')
   out.style.display = 'block'
   out.innerHTML = '<div class="alert alert-info">Rebuild en cours... (peut prendre 1-2 min)</div>'
@@ -153,7 +154,8 @@ export async function dockerRebuild() {
 }
 
 export async function nginxApply() {
-  if (!confirm('Appliquer nginx.conf et recharger Nginx ?')) return
+  const ok = await confirmAction('Appliquer nginx.conf et recharger Nginx ?', { title: 'Nginx', confirmText: 'Appliquer' })
+  if (!ok) return
   const out = document.getElementById('nginx-output')
   out.style.display = 'block'
   out.innerHTML = '<div class="alert alert-info">Application en cours...</div>'

--- a/server/public/admin/modules/monitor.js
+++ b/server/public/admin/modules/monitor.js
@@ -90,7 +90,7 @@ function renderServer(d) {
   }
 
   // ── Services (bare-metal uniquement) ──
-  if (d.services) {
+  if (d.services && typeof d.services === 'object') {
     html += `
     <div class="card">
       <div class="card-title">Services</div>
@@ -100,19 +100,22 @@ function renderServer(d) {
         <div class="svc"><div class="dot ${d.services.fail2ban === 'active' ? 'ok' : 'ko'}"></div>Fail2ban</div>
         <div class="svc"><div class="dot ${d.services.ufw?.includes('active') ? 'ok' : 'ko'}"></div>UFW</div>
       </div>
-      <div class="card-sub" style="margin-top:.75rem">IPs bannies: <strong>${d.security.bannedIPs}</strong></div>
-    </div>
+      ${d.security ? `<div class="card-sub" style="margin-top:.75rem">IPs bannies: <strong>${d.security.bannedIPs ?? 0}</strong></div>` : ''}
+    </div>`
+    if (d.security?.certs?.length) {
+      html += `
     <div class="card">
       <div class="card-title">Certificats SSL</div>
-      ${d.security.certs.length ? d.security.certs.map(c => `
+      ${d.security.certs.map(c => `
         <div class="cert">
           <span class="cert-name">${escHtml(c.name)}</span>
           <span style="color:${c.valid ? 'var(--green)' : 'var(--red)'}">
             ${c.valid ? '\u2713' : '\u2717'} ${escHtml(c.expiry || '\u2014')}
           </span>
         </div>
-      `).join('') : '<div class="card-sub">Aucun certificat d\u00e9tect\u00e9</div>'}
+      `).join('')}
     </div>`
+    }
   }
 
   // ── Docker / PM2 (bare-metal : containers détectés, Docker : non disponible) ──

--- a/server/public/admin/style.css
+++ b/server/public/admin/style.css
@@ -1,37 +1,38 @@
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 :root {
-  --bg: #08090c; --bg-card: #13151b; --bg-card-hover: #191c24;
-  --accent: #4A90D9; --green: #2ECC71; --orange: #F39C12; --red: #E74C3C;
-  --text: #e2e4e8; --text-secondary: #8b8f98; --text-muted: #4e5260;
-  --border: rgba(255,255,255,.06); --radius: 14px; --radius-sm: 8px;
+  --bg: #f5f7fa; --bg-card: #ffffff; --bg-card-hover: #f0f4f8;
+  --accent: #4A90D9; --green: #22c55e; --orange: #f59e0b; --red: #ef4444;
+  --text: #1e293b; --text-secondary: #64748b; --text-muted: #94a3b8;
+  --border: rgba(0,0,0,.08); --radius: 12px; --radius-sm: 8px;
   --font: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --shadow-sm: 0 1px 3px rgba(0,0,0,.06);
+  --shadow: 0 2px 8px rgba(0,0,0,.06);
+  --shadow-lg: 0 4px 16px rgba(0,0,0,.08);
 }
 body { font-family: var(--font); background: var(--bg); color: var(--text); min-height: 100vh; }
 a { color: var(--accent); text-decoration: none; }
 
 /* ── Layout ── */
-.container { max-width: 1280px; margin: 0 auto; padding: 2rem 1.5rem; }
-.header { display: flex; align-items: center; justify-content: space-between; margin-bottom: .5rem; }
-.header h1 { font-size: 1.5rem; font-weight: 700; }
-.header .status { display: flex; align-items: center; gap: .5rem; font-size: .85rem; color: var(--text-secondary); }
+.container { max-width: 1320px; margin: 0 auto; padding: 1.5rem; }
+.header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 1rem; padding-bottom: 1rem; border-bottom: 1px solid var(--border); }
+.header h1 { font-size: 1.35rem; font-weight: 700; color: var(--text); }
+.header .status { display: flex; align-items: center; gap: .5rem; font-size: .8rem; color: var(--text-secondary); }
 .header .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--green); }
 .header .dot.error { background: var(--red); }
 
 /* ── Login ── */
 .login-overlay {
-  position: fixed; inset: 0; background: var(--bg); display: flex;
-  align-items: center; justify-content: center; z-index: 100;
-  background-image: radial-gradient(ellipse at 30% 20%, rgba(74,144,217,.08) 0%, transparent 60%),
-                    radial-gradient(ellipse at 70% 80%, rgba(46,204,113,.05) 0%, transparent 50%);
+  position: fixed; inset: 0; background: linear-gradient(135deg, #e0e7ff 0%, #f0f4ff 50%, #e8f5e9 100%);
+  display: flex; align-items: center; justify-content: center; z-index: 100;
 }
 .login-box {
-  background: var(--bg-card); border: 1px solid var(--border);
-  border-radius: var(--radius); padding: 2.5rem; width: 380px;
-  box-shadow: 0 20px 60px rgba(0,0,0,.4);
+  background: #fff; border: 1px solid var(--border);
+  border-radius: var(--radius); padding: 2.5rem; width: 400px;
+  box-shadow: var(--shadow-lg);
 }
 .login-header { text-align: center; margin-bottom: 1.5rem; }
 .login-logo { width: 48px; height: 48px; margin-bottom: 10px; border-radius: 10px; }
-.login-header h2 { font-size: 1.2rem; font-weight: 700; margin-bottom: 4px; }
+.login-header h2 { font-size: 1.2rem; font-weight: 700; margin-bottom: 4px; color: var(--text); }
 .login-header p { font-size: .8rem; color: var(--text-secondary); }
 .login-field { position: relative; margin-bottom: .75rem; }
 .login-field label {
@@ -44,7 +45,7 @@ a { color: var(--accent); text-decoration: none; }
   color: var(--text); font-size: .9rem; outline: none;
   font-family: var(--font); transition: border-color .2s;
 }
-.login-box input:focus { border-color: var(--accent); box-shadow: 0 0 0 3px rgba(74,144,217,.15); }
+.login-box input:focus { border-color: var(--accent); box-shadow: 0 0 0 3px rgba(74,144,217,.12); }
 .login-box input::placeholder { color: var(--text-muted); }
 .login-submit {
   width: 100%; padding: .75rem; background: var(--accent); color: #fff;
@@ -58,29 +59,51 @@ a { color: var(--accent); text-decoration: none; }
 .login-box .error-msg {
   color: var(--red); font-size: .8rem; margin-top: .6rem;
   text-align: center; padding: 6px 10px; border-radius: 6px;
-  background: rgba(231,76,60,.08);
+  background: rgba(239,68,68,.06);
 }
 .login-footer { text-align: center; margin-top: 1rem; font-size: .75rem; color: var(--text-muted); }
 .login-footer a { color: var(--accent); }
 
 /* ── Tabs ── */
-.tab-btn { background: none; border: none; color: var(--text-muted); font-size: .85rem; font-weight: 500; padding: .75rem 1rem; cursor: pointer; border-bottom: 2px solid transparent; white-space: nowrap; transition: all .2s; }
-.tab-btn:hover { color: var(--text-secondary); }
-.tab-btn.active { color: var(--accent); border-bottom-color: var(--accent); }
+.tab-bar {
+  display: flex; gap: .25rem; margin-bottom: 1.5rem;
+  overflow-x: auto; scrollbar-width: thin; scrollbar-color: var(--border) transparent;
+  padding-bottom: .25rem; flex-wrap: wrap;
+}
+.tab-bar::-webkit-scrollbar { height: 4px; }
+.tab-bar::-webkit-scrollbar-thumb { background: var(--border); border-radius: 2px; }
+.tab-group { display: contents; }
+.tab-group-label { display: none; }
+.tab-group + .tab-group::before { display: none; }
+.tab-separator {
+  width: 1px; background: var(--border); margin: .25rem .35rem; flex-shrink: 0;
+}
+.tab-btn {
+  background: transparent; border: none; color: var(--text-muted);
+  font-size: .8rem; font-weight: 500; padding: .55rem .85rem;
+  cursor: pointer; border-radius: var(--radius-sm); white-space: nowrap;
+  transition: all .15s;
+}
+.tab-btn:hover { color: var(--text); background: rgba(0,0,0,.04); }
+.tab-btn.active { color: var(--accent); background: rgba(74,144,217,.08); font-weight: 600; }
 .tab-panel { display: none; }
-.tab-panel.active { display: block; }
+.tab-panel.active { display: block; animation: fadeIn .2s ease-out; }
 
 /* ── Grid ── */
-.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 1rem; margin-bottom: 1.5rem; }
+.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(340px, 1fr)); gap: 1rem; margin-bottom: 1.5rem; }
 
 /* ── Cards ── */
-.card { background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; }
-.card-title { font-size: .75rem; text-transform: uppercase; letter-spacing: .08em; color: var(--text-muted); margin-bottom: .75rem; }
-.card-value { font-size: 1.8rem; font-weight: 700; line-height: 1.2; }
+.card {
+  background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius);
+  padding: 1.5rem; box-shadow: var(--shadow-sm); transition: box-shadow .2s, border-color .2s;
+}
+.card:hover { box-shadow: var(--shadow); border-color: rgba(0,0,0,.12); }
+.card-title { font-size: .75rem; text-transform: uppercase; letter-spacing: .08em; color: var(--text-muted); margin-bottom: .75rem; font-weight: 600; }
+.card-value { font-size: 1.8rem; font-weight: 700; line-height: 1.2; color: var(--text); }
 .card-sub { font-size: .8rem; color: var(--text-secondary); margin-top: .25rem; }
 
 /* ── Progress bar ── */
-.bar-bg { height: 6px; background: rgba(255,255,255,.06); border-radius: 3px; margin-top: .75rem; overflow: hidden; }
+.bar-bg { height: 6px; background: rgba(0,0,0,.06); border-radius: 3px; margin-top: .75rem; overflow: hidden; }
 .bar-fill { height: 100%; border-radius: 3px; transition: width .5s ease; }
 .bar-fill.green { background: var(--green); }
 .bar-fill.orange { background: var(--orange); }
@@ -95,18 +118,18 @@ a { color: var(--accent); text-decoration: none; }
 
 /* ── Tables ── */
 .data-table { width: 100%; border-collapse: collapse; font-size: .8rem; }
-.data-table th { text-align: left; color: var(--text-muted); font-weight: 500; padding: .5rem .5rem; border-bottom: 1px solid var(--border); }
-.data-table td { padding: .5rem; border-bottom: 1px solid var(--border); }
+.data-table th { text-align: left; color: var(--text-muted); font-weight: 600; padding: .6rem .5rem; border-bottom: 2px solid var(--border); font-size: .7rem; text-transform: uppercase; letter-spacing: .04em; }
+.data-table td { padding: .6rem .5rem; border-bottom: 1px solid var(--border); }
 .data-table tr:last-child td { border-bottom: none; }
-.data-table tr:hover td { background: var(--bg-card-hover); }
+.data-table tr:hover td { background: var(--bg); }
 
 .badge { padding: 2px 8px; border-radius: 10px; font-size: .7rem; font-weight: 600; text-transform: uppercase; display: inline-block; }
-.badge.online, .badge.teacher { background: rgba(46,204,113,.15); color: var(--green); }
-.badge.stopped, .badge.danger { background: rgba(231,76,60,.15); color: var(--red); }
-.badge.student { background: rgba(74,144,217,.15); color: var(--accent); }
-.badge.ta      { background: rgba(243,156,18,.15); color: var(--orange); }
-.badge.info    { background: rgba(74,144,217,.1); color: var(--accent); }
-.badge.warn    { background: rgba(243,156,18,.1); color: var(--orange); }
+.badge.online, .badge.teacher { background: rgba(34,197,94,.1); color: #16a34a; }
+.badge.stopped, .badge.danger { background: rgba(239,68,68,.08); color: var(--red); }
+.badge.student { background: rgba(74,144,217,.1); color: var(--accent); }
+.badge.ta      { background: rgba(245,158,11,.1); color: #d97706; }
+.badge.info    { background: rgba(74,144,217,.08); color: var(--accent); }
+.badge.warn    { background: rgba(245,158,11,.08); color: #d97706; }
 
 /* ── Certs ── */
 .cert { display: flex; justify-content: space-between; align-items: center; padding: .5rem 0; border-bottom: 1px solid var(--border); font-size: .85rem; }
@@ -115,18 +138,24 @@ a { color: var(--accent); text-decoration: none; }
 
 /* ── Git ── */
 .git-info { font-size: .85rem; line-height: 1.8; }
-.git-info code { background: var(--bg); padding: 2px 8px; border-radius: 4px; font-size: .8rem; }
+.git-info code { background: var(--bg); padding: 2px 8px; border-radius: 4px; font-size: .8rem; color: var(--text-secondary); }
 
 /* ── Wide card ── */
 .wide { grid-column: 1 / -1; }
 
 /* ── Buttons ── */
-.refresh-btn { background: none; border: 1px solid var(--border); color: var(--text-secondary); padding: .4rem .8rem; border-radius: var(--radius-sm); font-size: .8rem; cursor: pointer; }
-.refresh-btn:hover { border-color: var(--accent); color: var(--accent); }
-.btn { padding: .5rem 1rem; border: none; border-radius: var(--radius-sm); font-size: .8rem; font-weight: 600; cursor: pointer; transition: opacity .2s; }
+.refresh-btn {
+  background: var(--bg-card); border: 1px solid var(--border); color: var(--text-secondary);
+  padding: .4rem .8rem; border-radius: var(--radius-sm); font-size: .8rem; cursor: pointer;
+  box-shadow: var(--shadow-sm); transition: all .15s;
+}
+.refresh-btn:hover { border-color: var(--accent); color: var(--accent); box-shadow: var(--shadow); }
+.btn { padding: .5rem 1rem; border: none; border-radius: var(--radius-sm); font-size: .8rem; font-weight: 600; cursor: pointer; transition: all .15s; }
 .btn:hover { opacity: .85; }
 .btn-primary { background: var(--accent); color: #fff; }
+.btn-primary:hover { background: #3b82f6; }
 .btn-danger  { background: var(--red); color: #fff; }
+.btn-danger:hover { background: #dc2626; }
 .btn-sm { padding: .3rem .6rem; font-size: .7rem; }
 
 /* ── Back link ── */
@@ -134,57 +163,62 @@ a { color: var(--accent); text-decoration: none; }
 .back-link:hover { color: var(--accent); }
 
 /* ── Filters ── */
-.filters { display: flex; gap: .5rem; flex-wrap: wrap; margin-bottom: 1rem; }
+.filters { display: flex; gap: .5rem; flex-wrap: wrap; margin-bottom: 1rem; align-items: center; }
 .filters input, .filters select {
   padding: .5rem .75rem; background: var(--bg-card); border: 1px solid var(--border);
   border-radius: var(--radius-sm); color: var(--text); font-size: .8rem; outline: none;
+  box-shadow: var(--shadow-sm); transition: border-color .2s, box-shadow .2s;
 }
-.filters input:focus, .filters select:focus { border-color: var(--accent); }
+.filters input:focus, .filters select:focus { border-color: var(--accent); box-shadow: 0 0 0 3px rgba(74,144,217,.1); }
 .filters input { min-width: 180px; }
 
 /* ── Chart ── */
 .chart-container { display: flex; align-items: flex-end; gap: 2px; height: 120px; padding: .5rem 0; }
-.chart-bar { flex: 1; background: var(--accent); border-radius: 2px 2px 0 0; min-width: 4px; transition: height .3s; position: relative; }
-.chart-bar:hover { background: #6ab0ff; }
+.chart-bar { flex: 1; background: rgba(74,144,217,.6); border-radius: 3px 3px 0 0; min-width: 4px; transition: height .3s; position: relative; }
+.chart-bar:hover { background: var(--accent); }
 .chart-bar:hover::after { content: attr(data-tip); position: absolute; bottom: 100%; left: 50%; transform: translateX(-50%);
-  background: var(--bg-card); border: 1px solid var(--border); border-radius: 4px; padding: 2px 6px;
-  font-size: .65rem; white-space: nowrap; color: var(--text); pointer-events: none; }
+  background: var(--text); color: #fff; border-radius: 4px; padding: 3px 8px;
+  font-size: .65rem; white-space: nowrap; pointer-events: none; z-index: 5; }
 .chart-label { font-size: .6rem; color: var(--text-muted); text-align: center; margin-top: .25rem; }
 
 /* ── Stats counters ── */
 .counter-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: .75rem; margin-bottom: 1.5rem; }
-.counter { background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 1rem; text-align: center; }
-.counter-value { font-size: 1.6rem; font-weight: 700; }
+.counter { background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 1rem; text-align: center; box-shadow: var(--shadow-sm); }
+.counter-value { font-size: 1.6rem; font-weight: 700; color: var(--text); }
 .counter-label { font-size: .7rem; color: var(--text-muted); text-transform: uppercase; letter-spacing: .05em; margin-top: .25rem; }
 
 /* ── Modal ── */
-.modal-overlay { position: fixed; inset: 0; background: rgba(0,0,0,.6); z-index: 200; display: flex; align-items: center; justify-content: center; }
-.modal { background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius); padding: 2rem; min-width: 400px; max-width: 500px; }
-.modal h3 { margin-bottom: 1rem; }
+.modal-overlay { position: fixed; inset: 0; background: rgba(0,0,0,.3); backdrop-filter: blur(2px); z-index: 200; display: flex; align-items: center; justify-content: center; }
+.modal { background: #fff; border: 1px solid var(--border); border-radius: var(--radius); padding: 2rem; min-width: 400px; max-width: 500px; box-shadow: var(--shadow-lg); }
+.modal h3 { margin-bottom: 1rem; color: var(--text); }
 .modal input, .modal select, .modal textarea {
   width: 100%; padding: .5rem .75rem; background: var(--bg); border: 1px solid var(--border);
   border-radius: var(--radius-sm); color: var(--text); font-size: .85rem; margin-bottom: .5rem; outline: none;
 }
+.modal input:focus, .modal select:focus, .modal textarea:focus { border-color: var(--accent); box-shadow: 0 0 0 3px rgba(74,144,217,.1); }
 .modal-actions { display: flex; gap: .5rem; justify-content: flex-end; margin-top: 1rem; }
 
 /* ── Pagination ── */
 .pagination { display: flex; align-items: center; gap: .5rem; justify-content: center; margin-top: 1rem; font-size: .8rem; color: var(--text-secondary); }
-.pagination button { background: var(--bg-card); border: 1px solid var(--border); color: var(--text); padding: .3rem .6rem; border-radius: var(--radius-sm); cursor: pointer; font-size: .75rem; }
+.pagination button { background: var(--bg-card); border: 1px solid var(--border); color: var(--text); padding: .3rem .6rem; border-radius: var(--radius-sm); cursor: pointer; font-size: .75rem; box-shadow: var(--shadow-sm); }
+.pagination button:hover { border-color: var(--accent); }
 .pagination button:disabled { opacity: .3; cursor: default; }
+.pagination button.pg-active { background: var(--accent); color: #fff; border-color: var(--accent); }
+.pg-info { font-size: .7rem; color: var(--text-muted); margin-left: .5rem; }
 
 /* ── Alert banner ── */
 .alert { padding: .75rem 1rem; border-radius: var(--radius-sm); margin-bottom: 1rem; font-size: .8rem; }
-.alert-warn { background: rgba(243,156,18,.1); border: 1px solid rgba(243,156,18,.2); color: var(--orange); }
-.alert-danger { background: rgba(231,76,60,.1); border: 1px solid rgba(231,76,60,.2); color: var(--red); }
-.alert-info { background: rgba(74,144,217,.1); border: 1px solid rgba(74,144,217,.2); color: var(--accent); }
+.alert-warn { background: rgba(245,158,11,.06); border: 1px solid rgba(245,158,11,.15); color: #b45309; }
+.alert-danger { background: rgba(239,68,68,.06); border: 1px solid rgba(239,68,68,.15); color: var(--red); }
+.alert-info { background: rgba(74,144,217,.06); border: 1px solid rgba(74,144,217,.15); color: var(--accent); }
 
 /* ── Heatmap ── */
 .heatmap { display: grid; grid-template-columns: 40px repeat(24, 1fr); gap: 2px; font-size: .65rem; }
 .heatmap-label { display: flex; align-items: center; color: var(--text-muted); font-size: .65rem; }
 .heatmap-cell { aspect-ratio: 1; border-radius: 3px; position: relative; cursor: default; }
 .heatmap-cell:hover::after { content: attr(data-tip); position: absolute; bottom: 110%; left: 50%; transform: translateX(-50%);
-  background: var(--bg-card); border: 1px solid var(--border); border-radius: 4px; padding: 2px 6px;
-  font-size: .6rem; white-space: nowrap; color: var(--text); z-index: 10; pointer-events: none; }
+  background: var(--text); color: #fff; border-radius: 4px; padding: 3px 8px;
+  font-size: .6rem; white-space: nowrap; z-index: 10; pointer-events: none; }
 .heatmap-hour { text-align: center; color: var(--text-muted); font-size: .6rem; padding-bottom: 2px; }
 
 /* ── Tab badge ── */
@@ -193,19 +227,19 @@ a { color: var(--accent); text-decoration: none; }
 /* ── Toggle switch ── */
 .toggle { position: relative; display: inline-block; width: 44px; height: 24px; cursor: pointer; }
 .toggle input { opacity: 0; width: 0; height: 0; }
-.toggle-slider { position: absolute; inset: 0; background: var(--border); border-radius: 12px; transition: .3s; }
-.toggle-slider::before { content: ''; position: absolute; width: 18px; height: 18px; left: 3px; top: 3px; background: var(--text); border-radius: 50%; transition: .3s; }
+.toggle-slider { position: absolute; inset: 0; background: #cbd5e1; border-radius: 12px; transition: .3s; }
+.toggle-slider::before { content: ''; position: absolute; width: 18px; height: 18px; left: 3px; top: 3px; background: #fff; border-radius: 50%; transition: .3s; box-shadow: 0 1px 3px rgba(0,0,0,.15); }
 .toggle input:checked + .toggle-slider { background: var(--accent); }
 .toggle input:checked + .toggle-slider::before { transform: translateX(20px); }
 
 /* ── Archived badge ── */
-.badge.archived { background: rgba(78,82,96,.2); color: var(--text-muted); }
-.badge.pending  { background: rgba(243,156,18,.15); color: var(--orange); }
-.badge.reviewed { background: rgba(46,204,113,.15); color: var(--green); }
-.badge.dismissed { background: rgba(78,82,96,.2); color: var(--text-muted); }
+.badge.archived { background: rgba(148,163,184,.12); color: var(--text-muted); }
+.badge.pending  { background: rgba(245,158,11,.1); color: #d97706; }
+.badge.reviewed { background: rgba(34,197,94,.1); color: #16a34a; }
+.badge.dismissed { background: rgba(148,163,184,.12); color: var(--text-muted); }
 
 /* ── Docker badge ── */
-.badge.docker-badge { background: rgba(74,144,217,.15); color: var(--accent); font-size: .6rem; vertical-align: middle; }
+.badge.docker-badge { background: rgba(74,144,217,.1); color: var(--accent); font-size: .6rem; vertical-align: middle; }
 
 /* ── Env list (monitor Docker) ── */
 .env-list { display: flex; flex-direction: column; gap: .4rem; }
@@ -213,43 +247,27 @@ a { color: var(--accent); text-decoration: none; }
 .env-key { font-weight: 600; color: var(--text-secondary); min-width: 80px; }
 .env-row code { background: var(--bg); padding: 2px 8px; border-radius: 4px; font-size: .75rem; }
 
-/* ── Tab groups ── */
-.tab-bar { display: flex; gap: 0; border-bottom: 1px solid var(--border); margin-bottom: 1.5rem; overflow-x: auto; scrollbar-width: thin; scrollbar-color: var(--border) transparent; }
-.tab-bar::-webkit-scrollbar { height: 4px; }
-.tab-bar::-webkit-scrollbar-thumb { background: var(--border); border-radius: 2px; }
-.tab-group { display: flex; align-items: flex-end; gap: .1rem; position: relative; }
-.tab-group + .tab-group { margin-left: .25rem; padding-left: .5rem; }
-.tab-group + .tab-group::before {
-  content: ''; position: absolute; left: 0; top: 20%; bottom: 20%;
-  width: 1px; background: var(--border);
-}
-.tab-group-label {
-  position: absolute; top: -2px; left: .5rem;
-  font-size: .5rem; text-transform: uppercase; letter-spacing: .08em;
-  color: var(--text-muted); pointer-events: none; white-space: nowrap;
-}
-
-/* ── Section title (stats) ── */
+/* ── Section title ── */
 .section-title {
-  font-size: .85rem; font-weight: 700; text-transform: uppercase; letter-spacing: .06em;
+  font-size: .8rem; font-weight: 700; text-transform: uppercase; letter-spacing: .06em;
   color: var(--text-secondary); margin-bottom: 1rem; padding-bottom: .5rem;
   border-bottom: 1px solid var(--border);
 }
 .section-divider { border: none; border-top: 1px solid var(--border); margin: 1.5rem 0; }
 
 /* ── Visit counters accent ── */
-.counter.accent { border-color: rgba(74,144,217,.2); }
+.counter.accent { border-color: rgba(74,144,217,.15); background: rgba(74,144,217,.03); }
 .counter.accent .counter-value { color: var(--accent); }
 
 /* ── Stacked bar chart (logins) ── */
 .chart-stacked { display: flex; align-items: flex-end; gap: 2px; height: 120px; padding: .5rem 0; }
 .chart-bar-stack {
-  flex: 1; display: flex; flex-direction: column; min-width: 4px; border-radius: 2px 2px 0 0;
+  flex: 1; display: flex; flex-direction: column; min-width: 4px; border-radius: 3px 3px 0 0;
   overflow: hidden; position: relative; cursor: default;
 }
 .chart-bar-stack:hover::after { content: attr(data-tip); position: absolute; bottom: 100%; left: 50%; transform: translateX(-50%);
-  background: var(--bg-card); border: 1px solid var(--border); border-radius: 4px; padding: 2px 6px;
-  font-size: .65rem; white-space: nowrap; color: var(--text); pointer-events: none; z-index: 5; }
+  background: var(--text); color: #fff; border-radius: 4px; padding: 3px 8px;
+  font-size: .65rem; white-space: nowrap; pointer-events: none; z-index: 5; }
 .bar-success { background: var(--green); width: 100%; }
 .bar-fail { background: var(--red); width: 100%; }
 
@@ -259,16 +277,16 @@ a { color: var(--accent); text-decoration: none; }
 
 /* ── Hour bar chart ── */
 .chart-hours { display: flex; align-items: flex-end; gap: 1px; height: 80px; padding: .5rem 0; }
-.chart-hours .chart-bar { background: rgba(74,144,217,.5); }
+.chart-hours .chart-bar { background: rgba(74,144,217,.4); }
 .chart-hours .chart-bar:hover { background: var(--accent); }
 
 /* ── Visit bar ── */
-.visit-bar { background: rgba(74,144,217,.6); }
+.visit-bar { background: rgba(74,144,217,.5); }
 .visit-bar:hover { background: var(--accent); }
 
 /* ── Deploy Docker info ── */
 .deploy-docker-msg {
-  padding: 1rem 1.25rem; background: rgba(74,144,217,.06); border: 1px solid rgba(74,144,217,.15);
+  padding: 1.25rem 1.5rem; background: rgba(74,144,217,.04); border: 1px solid rgba(74,144,217,.12);
   border-radius: var(--radius-sm); color: var(--text-secondary); font-size: .85rem; line-height: 1.6;
 }
 .deploy-docker-msg code { background: var(--bg); padding: 2px 6px; border-radius: 4px; font-size: .8rem; }
@@ -282,8 +300,8 @@ a { color: var(--accent); text-decoration: none; }
 .toast {
   display: flex; align-items: center; gap: .6rem; padding: .65rem 1rem;
   border-radius: var(--radius-sm); font-size: .8rem; pointer-events: auto;
-  box-shadow: 0 8px 30px rgba(0,0,0,.4); border: 1px solid var(--border);
-  background: var(--bg-card); color: var(--text);
+  box-shadow: var(--shadow-lg); border: 1px solid var(--border);
+  background: #fff; color: var(--text);
   transform: translateX(120%); transition: transform .3s cubic-bezier(.4,0,.2,1), opacity .3s;
   opacity: 0;
 }
@@ -329,7 +347,7 @@ a { color: var(--accent); text-decoration: none; }
 .skeleton-container { padding: 1rem 0; }
 .skeleton-line {
   height: 12px; border-radius: 4px; margin-bottom: .75rem;
-  background: linear-gradient(90deg, rgba(255,255,255,.04) 25%, rgba(255,255,255,.08) 50%, rgba(255,255,255,.04) 75%);
+  background: linear-gradient(90deg, rgba(0,0,0,.04) 25%, rgba(0,0,0,.08) 50%, rgba(0,0,0,.04) 75%);
   background-size: 200% 100%;
   animation: shimmer 1.5s infinite;
 }
@@ -346,29 +364,20 @@ a { color: var(--accent); text-decoration: none; }
 .empty-icon { font-size: 2.5rem; margin-bottom: .75rem; opacity: .5; }
 .empty-msg { font-size: .85rem; color: var(--text-muted); max-width: 300px; line-height: 1.5; }
 
-/* ── Better pagination ── */
-.pagination button.pg-active { background: var(--accent); color: #fff; border-color: var(--accent); }
-.pg-info { font-size: .7rem; color: var(--text-muted); margin-left: .5rem; }
-
-/* ── Card entrance animation ── */
-.card { transition: border-color .2s, box-shadow .2s; }
-.card:hover { border-color: rgba(255,255,255,.1); box-shadow: 0 4px 20px rgba(0,0,0,.2); }
-
 /* ── Table row actions ── */
-.row-actions { display: flex; gap: .25rem; opacity: .6; transition: opacity .15s; }
+.row-actions { display: flex; gap: .25rem; opacity: .5; transition: opacity .15s; }
 tr:hover .row-actions { opacity: 1; }
 
 /* ── Inline status change ── */
 .status-select {
-  padding: .2rem .4rem; background: var(--bg); border: 1px solid var(--border);
+  padding: .25rem .5rem; background: var(--bg); border: 1px solid var(--border);
   border-radius: 4px; color: var(--text); font-size: .7rem; outline: none; cursor: pointer;
 }
 .status-select:focus { border-color: var(--accent); }
 
 /* ── Tab panel fade-in ── */
-.tab-panel.active { animation: fadeIn .25s ease-out; }
 @keyframes fadeIn {
-  from { opacity: 0; transform: translateY(6px); }
+  from { opacity: 0; transform: translateY(4px); }
   to { opacity: 1; transform: translateY(0); }
 }
 
@@ -384,9 +393,9 @@ tr:hover .row-actions { opacity: 1; }
 /* ── Stat card (feedback) ── */
 .stat-card {
   background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius-sm);
-  padding: .75rem; text-align: center; transition: border-color .2s;
+  padding: .75rem; text-align: center; box-shadow: var(--shadow-sm); transition: all .2s;
 }
-.stat-card:hover { border-color: rgba(255,255,255,.12); }
+.stat-card:hover { box-shadow: var(--shadow); }
 .stat-value { font-size: 1.5rem; font-weight: 700; }
 .stat-label { font-size: .65rem; text-transform: uppercase; letter-spacing: .05em; color: var(--text-muted); margin-top: .15rem; }
 
@@ -399,17 +408,7 @@ tr:hover .row-actions { opacity: 1; }
 .action-btn:hover { border-color: var(--accent); color: var(--accent); }
 .action-btn.action-primary { background: var(--accent); color: #fff; border-color: var(--accent); }
 
-/* ── Better filter bar ── */
-.filters { display: flex; gap: .5rem; flex-wrap: wrap; margin-bottom: 1rem; align-items: center; }
-.filters input, .filters select {
-  padding: .5rem .75rem; background: var(--bg-card); border: 1px solid var(--border);
-  border-radius: var(--radius-sm); color: var(--text); font-size: .8rem; outline: none;
-  transition: border-color .2s, box-shadow .2s;
-}
-.filters input:focus, .filters select:focus { border-color: var(--accent); box-shadow: 0 0 0 3px rgba(74,144,217,.1); }
-.filters input { min-width: 180px; }
-
-/* ── Counter grid responsive ── */
+/* ── Responsive ── */
 @media (max-width: 768px) {
   .container { padding: 1rem .75rem; }
   .counter-grid { grid-template-columns: repeat(auto-fill, minmax(100px, 1fr)); gap: .5rem; }
@@ -418,4 +417,6 @@ tr:hover .row-actions { opacity: 1; }
   .grid { grid-template-columns: 1fr; }
   .modal { min-width: unset; width: 90vw; max-width: 90vw; }
   .header { flex-direction: column; gap: .5rem; align-items: flex-start; }
+  .tab-bar { gap: .15rem; }
+  .tab-btn { padding: .45rem .65rem; font-size: .75rem; }
 }


### PR DESCRIPTION
- Replace dark theme (--bg: #08090c) with light theme (--bg: #f5f7fa, white cards)
- Replace broken tab-group labels with simple flat tabs and visual separators
- Increase grid min-width from 280px to 340px for larger widgets
- Add subtle shadows and hover effects for depth on light backgrounds
- Fix services/nginx null error with safer typeof check in monitor.js
- Add null safety for d.security and d.security.certs
- Replace native confirm() with confirmAction() in deploy.js
- Improve modal overlay with backdrop blur
- Update login page gradient to light welcoming colors
- Better responsive styles for mobile

https://claude.ai/code/session_01M3vDKTrLWRFzX6etMni86L