### PR TITLE
test(e2e): couverture Playwright — devoirs, messages, auth étudiant

### DIFF
--- a/tests/e2e/devoirs.spec.ts
+++ b/tests/e2e/devoirs.spec.ts
@@ -1,0 +1,51 @@
+/**
+ * Tests E2E – Devoirs
+ *
+ * Flows couverts :
+ *   1. Étudiant : navigation vers /devoirs → page chargée sans erreur réseau
+ *   2. Enseignant : navigation vers /devoirs → vue enseignant (pas l'état vide étudiant)
+ *
+ * Prérequis : le compte STUDENT est provisionné via API avant les tests.
+ */
+import { test, expect } from '@playwright/test'
+import {
+  TEACHER,
+  STUDENT,
+  loginAndWaitDashboard,
+  navigateTo,
+  provisionStudent,
+} from './helpers'
+
+test.describe('Devoirs', () => {
+  test.beforeAll(async () => {
+    await provisionStudent()
+  })
+
+  test('étudiant : la page devoirs charge sans erreur', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    await navigateTo(page, 'devoirs')
+
+    // La zone racine devoirs est bien montée dans le DOM
+    await expect(page.locator('.devoirs-area')).toBeVisible({ timeout: 15_000 })
+
+    // S'il y a un titre d'état vide visible, ce ne doit pas être une erreur réseau
+    const esTitle = page.locator('.es-title')
+    if (await esTitle.isVisible({ timeout: 2_000 }).catch(() => false)) {
+      await expect(esTitle).not.toHaveText(/Impossible de charger/i)
+    }
+  })
+
+  test('enseignant : la page devoirs affiche la vue professeur', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    await navigateTo(page, 'devoirs')
+
+    // Le conteneur de contenu devoirs est visible
+    await expect(page.locator('.devoirs-content')).toBeVisible({ timeout: 15_000 })
+
+    // L'enseignant ne doit jamais voir l'état vide réservé aux étudiants sans devoirs
+    const esTitle = page.locator('.es-title')
+    if (await esTitle.isVisible({ timeout: 2_000 }).catch(() => false)) {
+      await expect(esTitle).not.toHaveText('Aucun devoir assigné')
+    }
+  })
+})

--- a/tests/e2e/messages.spec.ts
+++ b/tests/e2e/messages.spec.ts
@@ -1,0 +1,32 @@
+/**
+ * Tests E2E – Messages
+ *
+ * Flows couverts :
+ *   1. Navigation vers /messages → zone principale (#main-area) chargée et URL correcte
+ *   2. Sidebar : au moins un canal visible après connexion enseignant
+ *
+ * Prérequis : compte enseignant TEACHER (rfosse@cesi.fr) + base seedée avec canaux.
+ */
+import { test, expect } from '@playwright/test'
+import { TEACHER, loginAndWaitDashboard, navigateTo } from './helpers'
+
+test.describe('Messages', () => {
+  test('la page messages est accessible depuis la NavRail', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    await navigateTo(page, 'messages')
+
+    // La zone principale des messages est montée dans le DOM
+    await expect(page.locator('#main-area')).toBeAttached({ timeout: 15_000 })
+    await expect(page).toHaveURL(/messages/)
+  })
+
+  test('la sidebar liste au moins un canal après connexion', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    await navigateTo(page, 'messages')
+
+    // ChannelItem rend : <button class="sidebar-item"><span class="channel-name">…</span></button>
+    // La base de test est seedée avec au moins un canal "general" par promo
+    const firstChannel = page.locator('.sidebar-item .channel-name').first()
+    await expect(firstChannel).toBeVisible({ timeout: 15_000 })
+  })
+})

--- a/tests/e2e/student-auth.spec.ts
+++ b/tests/e2e/student-auth.spec.ts
@@ -1,0 +1,47 @@
+/**
+ * Tests E2E – Authentification étudiant
+ *
+ * Flows couverts :
+ *   1. Connexion étudiant → tableau de bord (#app-shell visible, URL /dashboard)
+ *   2. Déconnexion via Paramètres → retour au formulaire de login
+ *
+ * Prérequis : compte STUDENT provisionné via API avant les tests.
+ *
+ * Séquence de déconnexion :
+ *   #nav-user-avatar  →  .stg-nav-danger ("Se deconnecter")  →  .cfm-confirm (confirmation)
+ */
+import { test, expect } from '@playwright/test'
+import { STUDENT, SEL, loginAndWaitDashboard, provisionStudent } from './helpers'
+
+test.describe('Authentification étudiant', () => {
+  test.beforeAll(async () => {
+    await provisionStudent()
+  })
+
+  test('un étudiant peut se connecter et accéder au tableau de bord', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+
+    await expect(page.locator('#app-shell')).toBeVisible()
+    await expect(page).toHaveURL(/dashboard/)
+  })
+
+  test('un étudiant peut se déconnecter via les paramètres', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+
+    // Ouvrir la modale Paramètres via le bouton avatar dans la NavRail
+    await page.locator('#nav-user-avatar').click()
+
+    // Cliquer sur "Se deconnecter" dans la navigation latérale de la modale
+    const logoutBtn = page.locator('.stg-nav-danger')
+    await expect(logoutBtn).toBeVisible({ timeout: 10_000 })
+    await logoutBtn.click()
+
+    // Une modale de confirmation apparaît (.cfm-confirm = bouton primaire de ConfirmModal)
+    const confirmBtn = page.locator('.cfm-confirm')
+    await expect(confirmBtn).toBeVisible({ timeout: 5_000 })
+    await confirmBtn.click()
+
+    // Après déconnexion, le formulaire de login est à nouveau visible
+    await expect(page.locator(SEL.emailInput)).toBeVisible({ timeout: 15_000 })
+  })
+})

--- a/tests/e2e/tsconfig.json
+++ b/tests/e2e/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "lib": ["ES2020", "DOM"],
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["./**/*.ts"]
+}


### PR DESCRIPTION
## Résumé

Ajout de 3 nouveaux fichiers de tests Playwright couvrant les flows critiques non couverts par les specs existantes (`auth.spec.ts` ne testait que la connexion enseignant ; `cross-promo-isolation.spec.ts` est intégralement skippé).

---

## Flows couverts

| Priorité | Fichier | Tests |
|---|---|---|
| **auth** | `student-auth.spec.ts` | Connexion étudiant → `#app-shell` visible + URL `/dashboard` |
| **auth** | `student-auth.spec.ts` | Déconnexion complète : avatar → `.stg-nav-danger` → confirmation `.cfm-confirm` → retour login |
| **devoirs** | `devoirs.spec.ts` | Étudiant → `/devoirs` se charge sans erreur réseau (`.devoirs-area` visible) |
| **devoirs** | `devoirs.spec.ts` | Enseignant → `/devoirs` affiche la vue professeur (jamais "Aucun devoir assigné") |
| **messages** | `messages.spec.ts` | Navigation vers `/messages` → `#main-area` attaché dans le DOM |
| **messages** | `messages.spec.ts` | Sidebar liste ≥ 1 canal après connexion (`.sidebar-item .channel-name`) |

---

## Détails techniques

- **Sélecteurs** dérivés du code source Vue réel (`ChannelItem.vue`, `SettingsModal.vue`, `ConfirmModal.vue`, etc.) — pas de sélecteurs fragiles sur le texte rendu.
- **`provisionStudent()`** appelé en `beforeAll` dans les deux specs qui en ont besoin, idempotent (ignore le 409).
- **`navigateTo()`** du helper existant utilisé pour la navigation (multi-sélecteur `aria-label` + `.nav-label`).
- **`tests/e2e/tsconfig.json`** ajouté pour permettre `npx tsc --noEmit -p tests/e2e/tsconfig.json` — 0 erreur au commit.

## Plan de test

- [ ] `npx playwright test tests/e2e/student-auth.spec.ts` avec serveur + seed de base
- [ ] `npx playwright test tests/e2e/devoirs.spec.ts` idem
- [ ] `npx playwright test tests/e2e/messages.spec.ts` idem
- [ ] Vérifier que les tests existants (`auth.spec.ts`) passent toujours

https://claude.ai/code/session_016UBg7tMRmwDkdgara9YWwB