### PR TITLE
test(e2e): add Playwright tests for devoirs, messages, and role-based access

### DIFF
--- a/tests/e2e/devoirs.spec.ts
+++ b/tests/e2e/devoirs.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test'
+import { loginAndWaitDashboard, navigateTo, provisionStudent, STUDENT } from './helpers'
+
+test.describe('Devoirs', () => {
+  test.beforeAll(async () => {
+    await provisionStudent()
+  })
+
+  test('un etudiant peut acceder a la page des devoirs et voir son contenu', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    await navigateTo(page, 'devoirs')
+    await expect(page).toHaveURL(/devoirs/)
+    // La vue est montee et contient un element principal visible
+    await expect(page.locator('main').first()).toBeVisible({ timeout: 10_000 })
+  })
+})

--- a/tests/e2e/messages.spec.ts
+++ b/tests/e2e/messages.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test'
+import { loginAndWaitDashboard, navigateTo, provisionStudent, STUDENT } from './helpers'
+
+test.describe('Messages', () => {
+  test.beforeAll(async () => {
+    await provisionStudent()
+  })
+
+  test('un etudiant peut acceder a la messagerie et voir la liste des canaux', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    await navigateTo(page, 'messages')
+    await expect(page).toHaveURL(/messages/)
+    // La sidebar/liste de canaux est rendue
+    const channelList = page.locator(
+      '[class*="channel"], [class*="sidebar"], aside, [data-testid*="channel"]'
+    ).first()
+    await expect(channelList).toBeVisible({ timeout: 10_000 })
+  })
+})

--- a/tests/e2e/role-access.spec.ts
+++ b/tests/e2e/role-access.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test'
+import { loginAndWaitDashboard, provisionStudent, STUDENT, TEACHER } from './helpers'
+
+test.describe('Controle acces par role', () => {
+  test.beforeAll(async () => {
+    await provisionStudent()
+  })
+
+  test('un etudiant est redirige vers le dashboard en tentant d\'acceder a /fichiers (teacher only)', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    await page.goto('/#/fichiers')
+    await expect(page).toHaveURL(/dashboard/, { timeout: 10_000 })
+  })
+
+  test('un enseignant peut acceder a la route /fichiers', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    await page.goto('/#/fichiers')
+    await expect(page).toHaveURL(/fichiers/, { timeout: 10_000 })
+    await expect(page.locator('main').first()).toBeVisible({ timeout: 10_000 })
+  })
+})


### PR DESCRIPTION
## Flows couverts

Trois parcours critiques non couverts par les tests existants (`auth.spec.ts`, `cross-promo-isolation.spec.ts`) :

| Fichier | Flow | Priorité |
|---|---|---|
| `devoirs.spec.ts` | Étudiant connecté → navigation `/devoirs` → page rendue | devoirs |
| `messages.spec.ts` | Étudiant connecté → navigation `/messages` → sidebar canaux visible | messages |
| `role-access.spec.ts` | Étudiant → `/fichiers` redirigé vers `/dashboard` (guard `requiredRole: 'teacher'`) | admin |
| `role-access.spec.ts` | Enseignant → `/fichiers` accès autorisé | admin |

## Ce qui existait déjà (non dupliqué)

- Affichage page login ✓
- Rejet credentials invalides ✓
- Login enseignant + redirection dashboard ✓
- Isolation cross-promo canaux/devoirs (skipped, nécessite seed) ✓

## Patterns suivis

- Helpers partagés (`loginAndWaitDashboard`, `navigateTo`, `provisionStudent`, `STUDENT`, `TEACHER`)
- `test.beforeAll` → `provisionStudent()` pour garantir l'existence du compte étudiant
- Sélecteurs multi-stratégie pour robustesse sur les composants Vue
- Timeouts explicites cohérents avec le reste de la suite (10-20 s)

https://claude.ai/code/session_01UF3ZVhDiGFdRWQQJP65tUQ