### PR TITLE
test(e2e): 3 nouveaux tests Playwright pour les flows critiques

### DIFF
--- a/tests/e2e/devoirs.spec.ts
+++ b/tests/e2e/devoirs.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test'
+import { TEACHER, STUDENT, provisionStudent, loginAndWaitDashboard } from './helpers'
+
+/**
+ * Flows couverts : accès à la section Devoirs selon le rôle.
+ *
+ * Parcours étudiant :
+ *   1. Provisionnement du compte étudiant de test via l'API
+ *   2. Connexion en tant qu'étudiant
+ *   3. Fermeture de l'assistant d'intégration (onboarding) s'il apparaît
+ *   4. Navigation directe vers /#/devoirs
+ *   5. Vérification que la zone devoirs charge la vue étudiant (pas la vue prof)
+ *
+ * Parcours enseignant :
+ *   1. Connexion en tant qu'enseignant
+ *   2. Navigation directe vers /#/devoirs
+ *   3. Vérification que la zone devoirs charge la vue enseignant (pas la vue étudiant)
+ */
+test.describe('Devoirs', () => {
+  test.beforeAll(async () => {
+    await provisionStudent()
+  })
+
+  test('un étudiant voit sa vue devoirs sans les éléments de gestion enseignant', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+
+    // Fermer l'assistant d'intégration s'il apparaît (compte nouvellement créé)
+    const skipBtn = page.locator('button:has-text("Passer"), button:has-text("Ignorer"), button:has-text("Fermer")').first()
+    if (await skipBtn.isVisible({ timeout: 3_000 }).catch(() => false)) {
+      await skipBtn.click()
+    }
+
+    // Navigation directe pour éviter les éventuels overlays bloquants
+    await page.goto('/#/devoirs')
+    await expect(page).toHaveURL(/#\/devoirs/, { timeout: 10_000 })
+
+    // La zone principale des devoirs doit être rendue
+    await expect(page.locator('.devoirs-area')).toBeVisible({ timeout: 15_000 })
+
+    // Les éléments spécifiques à l'interface enseignant (toolbar « À traiter ») ne doivent pas apparaître
+    await expect(page.locator('.dh-toolbar')).not.toBeVisible()
+  })
+
+  test('un enseignant voit sa vue projets sans les éléments de suivi étudiant', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+
+    await page.goto('/#/devoirs')
+    await expect(page).toHaveURL(/#\/devoirs/, { timeout: 10_000 })
+
+    // La zone principale des devoirs doit être rendue
+    await expect(page.locator('.devoirs-area')).toBeVisible({ timeout: 15_000 })
+
+    // Les éléments spécifiques à la vue étudiant (récapitulatif personnel) ne doivent pas apparaître
+    await expect(page.locator('.sdv-summary-row')).not.toBeVisible()
+  })
+})

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -24,6 +24,12 @@ export const SEL = {
 // ── API helpers ──────────────────────────────────────────────────────────────
 let teacherToken: string | null = null
 
+interface ApiResponse {
+  ok: boolean
+  error?: string
+  data?: Record<string, unknown>
+}
+
 export async function getTeacherToken(): Promise<string> {
   if (teacherToken) return teacherToken
   const res = await fetch(`${API_BASE}/api/auth/login`, {
@@ -31,9 +37,9 @@ export async function getTeacherToken(): Promise<string> {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ email: TEACHER.email, password: TEACHER.password }),
   })
-  const data = await res.json()
+  const data = await res.json() as ApiResponse
   if (!data.ok) throw new Error(`Teacher login failed: ${data.error}`)
-  teacherToken = data.data.token
+  teacherToken = data.data?.token as string
   return teacherToken!
 }
 
@@ -50,7 +56,7 @@ export async function provisionStudent(): Promise<void> {
       promoId: STUDENT.promoId,
     }),
   })
-  const data = await res.json()
+  const data = await res.json() as ApiResponse
   // Ignore if already exists (409 or "déjà utilisée" error)
   if (!data.ok && res.status !== 409 && !data.error?.includes('déjà')) {
     throw new Error(`Student provisioning failed: ${data.error}`)

--- a/tests/e2e/logout.spec.ts
+++ b/tests/e2e/logout.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test'
+import { TEACHER, SEL, loginAndWaitDashboard } from './helpers'
+
+/**
+ * Flow couvert : déconnexion depuis la modal de paramètres.
+ *
+ * Parcours :
+ *   1. Connexion en tant qu'enseignant
+ *   2. Ouverture de la modal paramètres via l'avatar (bas du rail de nav)
+ *   3. Clic sur « Se déconnecter » → modal de confirmation
+ *   4. Validation de la confirmation
+ *   5. Vérification que l'écran de connexion réapparaît
+ */
+test.describe('Déconnexion (auth)', () => {
+  test('se déconnecter depuis les paramètres ramène au formulaire de connexion', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+
+    // Ouvrir la modal paramètres via le bouton avatar (bas du NavRail)
+    await page.click('#nav-user-avatar')
+
+    // Attendre que la modal de paramètres soit rendue (bouton de déconnexion visible)
+    const logoutBtn = page.locator('.stg-nav-danger').first()
+    await expect(logoutBtn).toBeVisible({ timeout: 10_000 })
+    await logoutBtn.click()
+
+    // Un modal de confirmation apparaît (ConfirmModal.vue)
+    const confirmBtn = page.locator('.cfm-confirm').first()
+    await expect(confirmBtn).toBeVisible({ timeout: 5_000 })
+    await confirmBtn.click()
+
+    // Après déconnexion, le formulaire de connexion doit réapparaître
+    await expect(page.locator(SEL.emailInput)).toBeVisible({ timeout: 10_000 })
+  })
+})

--- a/tests/e2e/messages.spec.ts
+++ b/tests/e2e/messages.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test'
+import { TEACHER, loginAndWaitDashboard, navigateTo } from './helpers'
+
+/**
+ * Flow couvert : navigation vers la section Messages.
+ *
+ * Parcours :
+ *   1. Connexion en tant qu'enseignant
+ *   2. Clic sur le bouton « Messages » du rail de navigation
+ *   3. Vérification que l'URL change vers /messages
+ *   4. Vérification que la zone principale des messages (#main-area) est rendue
+ *
+ * Ce test protège contre les régressions de chargement de MessagesView :
+ * erreur d'import, crash de composable, ou route inaccessible.
+ */
+test.describe('Messages (navigation)', () => {
+  test('naviguer vers Messages charge la zone de discussion', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+
+    // Cliquer sur le bouton Messages du NavRail
+    await navigateTo(page, 'messages')
+
+    // L'URL doit refléter la section messages
+    await expect(page).toHaveURL(/messages/, { timeout: 15_000 })
+
+    // La zone principale de la vue Messages doit être montée
+    await expect(page.locator('#main-area')).toBeVisible({ timeout: 15_000 })
+  })
+})

--- a/tests/e2e/tsconfig.json
+++ b/tests/e2e/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "lib": ["ES2020"],
+    "types": ["node"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["./**/*.ts"]
+}


### PR DESCRIPTION
## Résumé

Ajout de 3 tests Playwright couvrant les parcours critiques non testés, en priorité **auth > devoirs > messages**.

### Flows couverts

| Fichier | Flow | Priorité |
|---|---|---|
| `logout.spec.ts` | Déconnexion via la modal paramètres → retour au formulaire de connexion | auth |
| `devoirs.spec.ts` | Étudiant voit sa vue devoirs (sans toolbar enseignant) · Enseignant voit sa vue projets (sans récap étudiant) | devoirs |
| `messages.spec.ts` | Navigation vers `/messages` → rendu du `#main-area` | messages |

### Détail technique

- **`logout.spec.ts`** : login teacher → clic `#nav-user-avatar` → `SettingsModal` → `.stg-nav-danger` → `ConfirmModal (.cfm-confirm)` → vérification email input visible
- **`devoirs.spec.ts`** : provisionnement étudiant via API (beforeAll) · gestion de l'onboarding wizard · navigation directe `/#/devoirs` · assertions de non-présence des éléments de l'autre rôle (`.dh-toolbar` / `.sdv-summary-row`)
- **`messages.spec.ts`** : `navigateTo('messages')` helper existant · vérification `#main-area` monté

### Autres changements

- **`helpers.ts`** : ajout de l'interface `ApiResponse` pour typer les réponses `fetch` (correction des erreurs TypeScript `unknown` pré-existantes)
- **`tsconfig.json`** (tests/e2e) : configuration TypeScript dédiée pour `npx tsc --noEmit` propre sur les specs Playwright

### Pas de duplication

Les tests existants couvrent : login valide, login invalide, affichage page login, isolation cross-promo. Aucun des 3 nouveaux tests ne chevauche ces scénarios.

## Test plan

- [ ] `npx playwright test tests/e2e/logout.spec.ts` — nécessite backend sur :3001 avec compte `rfosse@cesi.fr`
- [ ] `npx playwright test tests/e2e/devoirs.spec.ts` — nécessite backend + étudiant provisionnable via `/api/auth/register`
- [ ] `npx playwright test tests/e2e/messages.spec.ts` — nécessite backend + frontend sur :5174
- [ ] `npx tsc --project tests/e2e/tsconfig.json` — doit passer sans erreur

https://claude.ai/code/session_015k7Dim8NZHiau5fUA1jBAT

---
_Generated by [Claude Code](https://claude.ai/code/session_015k7Dim8NZHiau5fUA1jBAT)_