### PR TITLE
test(e2e): devoirs, messages et route-guards — 3 nouveaux specs

### DIFF
--- a/tests/e2e/devoirs.spec.ts
+++ b/tests/e2e/devoirs.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test'
+import { TEACHER, STUDENT, loginAndWaitDashboard, provisionStudent } from './helpers'
+
+test.describe('Devoirs', () => {
+  test.beforeAll(async () => {
+    await provisionStudent()
+  })
+
+  test('un enseignant accède à la vue devoirs professeur', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    await page.goto('/#/devoirs')
+
+    await expect(page.locator('.devoirs-area')).toBeVisible({ timeout: 15_000 })
+
+    // .dh-toolbar ("À traiter") est exclusif à TeacherProjectHome ;
+    // si la base est vide pour cette promo, le bouton EmptyState "Créer un devoir" est affiché.
+    await expect(
+      page.locator('.dh-toolbar').or(page.locator('button', { hasText: 'Créer un devoir' })),
+    ).toBeVisible({ timeout: 12_000 })
+
+    // L'input de recherche propre à la vue étudiant ne doit pas être présent
+    await expect(page.locator('.sdv-search-input')).not.toBeVisible()
+  })
+
+  test('un étudiant accède à la vue devoirs étudiant', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    await page.goto('/#/devoirs')
+
+    await expect(page.locator('.devoirs-area')).toBeVisible({ timeout: 15_000 })
+
+    // La toolbar prof "À traiter" ne doit pas apparaître pour un étudiant
+    await expect(page.locator('.dh-toolbar')).not.toBeVisible({ timeout: 5_000 })
+
+    // La zone de contenu étudiant est montée (liste, squelette ou état vide)
+    await expect(page.locator('.devoirs-content')).toBeVisible({ timeout: 10_000 })
+  })
+})

--- a/tests/e2e/messages.spec.ts
+++ b/tests/e2e/messages.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test'
+import { TEACHER, STUDENT, loginAndWaitDashboard, provisionStudent } from './helpers'
+
+test.describe('Messages', () => {
+  test.beforeAll(async () => {
+    await provisionStudent()
+  })
+
+  test('un enseignant accède à la section messages', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    await page.goto('/#/messages')
+
+    await expect(page).toHaveURL(/messages/, { timeout: 10_000 })
+
+    // Soit un canal est sélectionné (#channel-header), soit l'écran d'accueil est affiché (#no-channel-hint)
+    await expect(
+      page.locator('#channel-header').or(page.locator('#no-channel-hint')),
+    ).toBeVisible({ timeout: 15_000 })
+  })
+
+  test('la barre de recherche est présente quand un canal est actif', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    await page.goto('/#/messages')
+
+    await expect(page).toHaveURL(/messages/, { timeout: 10_000 })
+
+    const channelHeader = page.locator('#channel-header')
+    if (await channelHeader.isVisible({ timeout: 8_000 }).catch(() => false)) {
+      // Un canal est sélectionné : la barre de recherche et le bouton membres doivent être accessibles
+      await expect(page.locator('#search-input')).toBeVisible()
+      await expect(page.locator('button[aria-label="Afficher les membres"]')).toBeVisible()
+    } else {
+      // Aucun canal sélectionné : l'accueil messages est attendu
+      await expect(page.locator('#no-channel-hint')).toBeVisible()
+    }
+  })
+
+  test('un étudiant accède à la section messages', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    await page.goto('/#/messages')
+
+    await expect(page).toHaveURL(/messages/, { timeout: 10_000 })
+
+    await expect(
+      page.locator('#channel-header').or(page.locator('#no-channel-hint')),
+    ).toBeVisible({ timeout: 15_000 })
+  })
+})

--- a/tests/e2e/route-guards.spec.ts
+++ b/tests/e2e/route-guards.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test'
+import { TEACHER, STUDENT, loginAndWaitDashboard, provisionStudent } from './helpers'
+
+/**
+ * Vérifie que le guard Vue Router (beforeEach) applique bien le contrôle d'accès
+ * par rôle défini dans router/index.ts :
+ *   - /admin    → requiredRole: 'admin'   (level 3)
+ *   - /fichiers → requiredRole: 'teacher' (level 2)
+ *
+ * Un rôle insuffisant doit déclencher une redirection vers /dashboard.
+ */
+test.describe('Guards de navigation (contrôle d\'accès)', () => {
+  test.beforeAll(async () => {
+    await provisionStudent()
+  })
+
+  test('un étudiant est redirigé depuis /admin vers le dashboard', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+
+    // /admin exige le rôle "admin" (level 3) ; un étudiant (level 0) doit être redirigé
+    await page.goto('/#/admin')
+
+    await expect(page).toHaveURL(/dashboard/, { timeout: 10_000 })
+  })
+
+  test('un étudiant est redirigé depuis /fichiers vers le dashboard', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+
+    // /fichiers exige le rôle "teacher" (level 2) ; un étudiant (level 0) doit être redirigé
+    await page.goto('/#/fichiers')
+
+    await expect(page).toHaveURL(/dashboard/, { timeout: 10_000 })
+  })
+
+  test('un enseignant peut accéder à /fichiers sans redirection', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+
+    // L'enseignant possède le rôle "teacher" (level 2) ≥ level requis → accès autorisé
+    await page.goto('/#/fichiers')
+
+    await expect(page).toHaveURL(/fichiers/, { timeout: 10_000 })
+  })
+})

--- a/tsconfig.e2e.json
+++ b/tsconfig.e2e.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2020", "DOM"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true
+  },
+  "include": ["tests/e2e/**/*.ts"]
+}


### PR DESCRIPTION
## Contexte

Les tests E2E existants couvrent uniquement l'authentification basique (affichage du login, rejet de credentials invalides, connexion enseignant). Les flows devoirs, messages et contrôle d'accès n'étaient pas couverts.

## Flows couverts

### `tests/e2e/devoirs.spec.ts` — Différenciation des vues par rôle
| Test | Flow |
|------|------|
| Enseignant → vue devoirs professeur | Vérifie que `.dh-toolbar` ("À traiter") ou le bouton "Créer un devoir" sont visibles — composants exclusifs à `TeacherProjectHome` |
| Étudiant → vue devoirs étudiant | Vérifie que `.dh-toolbar` est absent et que `.devoirs-content` est monté — `StudentDevoirsView` |

### `tests/e2e/messages.spec.ts` — Accessibilité de la section Messages
| Test | Flow |
|------|------|
| Enseignant → section messages | `#channel-header` ou `#no-channel-hint` visible après navigation |
| Barre de recherche dans un canal actif | `#search-input` + bouton membres visibles si canal sélectionné ; sinon écran d'accueil attendu |
| Étudiant → section messages | Même vérification structurelle pour le rôle étudiant |

### `tests/e2e/route-guards.spec.ts` — Contrôle d'accès par rôle (router guard)
| Test | Flow |
|------|------|
| Étudiant → `/admin` | Redirigé vers `/dashboard` (requiredRole: admin, level 3 > student level 0) |
| Étudiant → `/fichiers` | Redirigé vers `/dashboard` (requiredRole: teacher, level 2 > student level 0) |
| Enseignant → `/fichiers` | Accès autorisé, URL reste sur `/fichiers` |

## Infrastructure ajoutée

- **`tsconfig.e2e.json`** — config TypeScript dédiée aux tests E2E (`moduleResolution: bundler`, `lib: ES2020 + DOM`) pour permettre `npx tsc --project tsconfig.e2e.json --noEmit` sans polluer le tsconfig racine.

## Vérifications

- [x] `npx tsc --project tsconfig.e2e.json` → 0 erreurs
- [x] Tests suivent les patterns existants (`loginAndWaitDashboard`, `provisionStudent`, sélecteurs `#id`/`.class`)
- [x] Pas de duplication avec `auth.spec.ts` ni `cross-promo-isolation.spec.ts`
- [x] `test.beforeAll` appelle `provisionStudent()` (idempotent, ignore 409)

## Couverture avant / après

| Flow | Avant | Après |
|------|-------|-------|
| Auth | ✅ 3 tests | ✅ inchangé |
| Devoirs | ❌ | ✅ 2 tests |
| Messages | ❌ | ✅ 3 tests |
| Route guards | ❌ | ✅ 3 tests |
| Dashboard | ❌ | — (priorité suivante) |
| Admin | ❌ | partiellement via guards |

https://claude.ai/code/session_01KkYYdtDmNjsVZN1tuWUhyx

---
_Generated by [Claude Code](https://claude.ai/code/session_01KkYYdtDmNjsVZN1tuWUhyx)_