### PR TITLE
test(e2e): logout, vue étudiant devoirs et garde de route admin

### DIFF
--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect } from '@playwright/test'
+import { STUDENT, loginAndWaitDashboard, provisionStudent } from './helpers'
+
+test.describe('Administration – contrôle d\'accès', () => {
+
+  test.beforeAll(async () => {
+    await provisionStudent()
+  })
+
+  test('un étudiant accédant à /admin est redirigé vers le dashboard', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+
+    // Tentative d'accès direct à la route protégée (requiredRole: 'admin')
+    await page.goto('/#/admin')
+
+    // Le beforeEach guard doit rediriger vers /dashboard
+    await expect(page).toHaveURL(/dashboard/, { timeout: 10_000 })
+  })
+
+  test('le bouton Admin n\'est pas visible dans la NavRail pour un étudiant', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+
+    // v-if="appStore.isAdmin" dans NavRail : le bouton ne doit pas exister
+    await expect(
+      page.locator('button[aria-label="Administration"]')
+    ).not.toBeVisible()
+  })
+
+  test('la page admin affiche les 3 onglets avec une session admin', async ({ page }) => {
+    // Injecter une session admin avant le chargement de la page pour bypasser
+    // le route guard (qui lit localStorage, sans valider le token).
+    await page.addInitScript(() => {
+      localStorage.setItem('cc_session', JSON.stringify({
+        token: '__e2e_admin_token__',
+        id: 9999,
+        name: 'E2E Admin',
+        email: 'e2e-admin@test.fr',
+        type: 'admin',
+        promoId: null,
+      }))
+    })
+
+    // Mocker les appels API pour éviter que les 401 du token fictif
+    // ne déclenchent un logout automatique via cursus:auth-expired.
+    await page.route('**/api/**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ ok: true, data: {} }),
+      })
+    )
+
+    await page.goto('/#/admin')
+
+    // La nav d'onglets doit contenir les 3 entrées définies dans AdminView
+    const tabs = page.locator('nav[aria-label="Sections admin"] button.adm-tab')
+    await expect(tabs).toHaveCount(3, { timeout: 10_000 })
+    await expect(tabs.nth(0)).toContainText('Statistiques')
+    await expect(tabs.nth(1)).toContainText('Utilisateurs')
+    await expect(tabs.nth(2)).toContainText('Modules')
+  })
+
+})

--- a/tests/e2e/devoirs.spec.ts
+++ b/tests/e2e/devoirs.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test'
+import { STUDENT, loginAndWaitDashboard, navigateTo, provisionStudent } from './helpers'
+
+test.describe('Devoirs – vue étudiant', () => {
+
+  test.beforeAll(async () => {
+    await provisionStudent()
+  })
+
+  test('affiche la vue étudiant et non la vue enseignant', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    await navigateTo(page, 'devoirs')
+
+    // Vérification positive : la section "Progression globale" est propre à StudentDevoirsView
+    await expect(page.locator('.sdv-summary-title')).toBeVisible({ timeout: 15_000 })
+
+    // Vérification négative : la barre de recherche enseignant (TeacherProjectHome) ne doit pas apparaître
+    await expect(
+      page.locator('[aria-label="Rechercher un projet ou un devoir"]')
+    ).not.toBeVisible()
+  })
+
+  test('le dépôt de fichier est accessible depuis la liste des devoirs', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    await navigateTo(page, 'devoirs')
+
+    // La zone de contenu devoirs doit être rendue
+    await expect(page.locator('.devoirs-content')).toBeVisible({ timeout: 15_000 })
+
+    // L'en-tête devoirs est toujours présent (DevoirsHeader commun étudiant/prof)
+    await expect(page.locator('.devoirs-area')).toBeVisible()
+  })
+
+})

--- a/tests/e2e/logout.spec.ts
+++ b/tests/e2e/logout.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test'
+import { TEACHER, SEL, loginAndWaitDashboard } from './helpers'
+
+test.describe('Déconnexion', () => {
+
+  test('efface la session et réaffiche le formulaire de login', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+
+    // Ouvrir les paramètres via le bouton de la NavRail
+    await page.click('button[aria-label="Paramètres du compte"]')
+
+    // Le bouton "Se déconnecter" est dans la nav latérale du modal settings
+    const logoutBtn = page.locator('.stg-nav-danger')
+    await expect(logoutBtn).toBeVisible({ timeout: 10_000 })
+    await logoutBtn.click()
+
+    // Le formulaire de login doit réapparaître (LoginOverlay monté quand currentUser est null)
+    await expect(page.locator(SEL.emailInput)).toBeVisible({ timeout: 10_000 })
+
+    // La session localStorage doit être effacée
+    const session = await page.evaluate(() => localStorage.getItem('cc_session'))
+    expect(session).toBeNull()
+  })
+
+})


### PR DESCRIPTION
## Résumé

Ajout de 3 nouveaux fichiers de tests Playwright pour les flows critiques non couverts, générés par l'agent E2E (priorité : auth > devoirs > admin).

### Flows couverts

| Fichier | Tests | Flow |
|---|---|---|
| `logout.spec.ts` | 1 | **Auth** – clic sur « Se déconnecter » dans SettingsModal → `cc_session` effacé → `LoginOverlay` réaffiché |
| `devoirs.spec.ts` | 2 | **Devoirs** – un étudiant voit `StudentDevoirsView` (section « Progression globale ») et non la barre de recherche enseignant (`TeacherProjectHome`) ; rendu de `.devoirs-area` |
| `admin.spec.ts` | 3 | **Admin** – route guard `/admin` redirige un étudiant vers `/dashboard` ; bouton Admin absent de la NavRail pour un étudiant ; onglets Statistiques / Utilisateurs / Modules présents pour un rôle admin (session injectée via `addInitScript` + appels API mockés via `page.route`) |

### Décisions techniques

- **Logout** : sélecteur `.stg-nav-danger` (classe CSS stable dans `SettingsModal.vue`) plutôt que text matching sensible aux accents.
- **Devoirs étudiant** : assertion positive sur `.sdv-summary-title` + négative sur `[aria-label="Rechercher un projet ou un devoir"]` pour distinguer les deux vues sans coupler au contenu dynamique.
- **Admin tabs avec session fictive** : `page.addInitScript` pour écrire `cc_session` avant le montage Vue (évite la course avec la restauration de session), `page.route('**/api/**')` pour court-circuiter les 401 qui déclencheraient un `logout()` automatique via `cursus:auth-expired`.

### Vérification

```
npx tsc --noEmit --strict --module ESNext --moduleResolution bundler \
  tests/e2e/logout.spec.ts tests/e2e/devoirs.spec.ts tests/e2e/admin.spec.ts tests/e2e/helpers.ts
# → aucune erreur
```

## Test plan

- [ ] `npx playwright test tests/e2e/logout.spec.ts` avec serveur démarré
- [ ] `npx playwright test tests/e2e/devoirs.spec.ts` (nécessite `e2e-student@test.fr` provisionné)
- [ ] `npx playwright test tests/e2e/admin.spec.ts` (les 2 premiers tests provisionnent l'étudiant, le 3e mocke l'API)
- [ ] Vérifier qu'aucun test existant (`auth.spec.ts`, `demo-mode.spec.ts`) n'est régressé

https://claude.ai/code/session_01Jww8Y3ugsZof7BLhq18eKk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jww8Y3ugsZof7BLhq18eKk)_