### PR TITLE
test(e2e): couverture auth étudiant, devoirs, messages et contrôle d'accès

### DIFF
--- a/tests/e2e/access-control.spec.ts
+++ b/tests/e2e/access-control.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test'
+import { STUDENT, TEACHER, provisionStudent, loginAndWaitDashboard } from './helpers'
+
+/**
+ * Couverture : contrôle d'accès basé sur les rôles (route guard du router).
+ *
+ * Les routes /booking et /fichiers requièrent le rôle "teacher".
+ * Un étudiant accédant à ces URLs doit être redirigé vers /dashboard.
+ */
+test.describe('Contrôle d\'accès par rôle', () => {
+  test.beforeAll(async () => {
+    await provisionStudent()
+  })
+
+  test('un étudiant est redirigé depuis /booking (route enseignant)', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    await page.goto('/#/booking')
+    // Le route guard doit rediriger immédiatement vers /dashboard
+    await expect(page).toHaveURL(/dashboard/, { timeout: 10_000 })
+    await expect(page.locator('.dashboard-shell')).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('un étudiant est redirigé depuis /fichiers (route enseignant)', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    await page.goto('/#/fichiers')
+    await expect(page).toHaveURL(/dashboard/, { timeout: 10_000 })
+    await expect(page.locator('.dashboard-shell')).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('un enseignant peut accéder à /booking sans redirection', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    await page.goto('/#/booking')
+    // L'enseignant doit rester sur /booking (pas de redirect)
+    await expect(page).toHaveURL(/booking/, { timeout: 10_000 })
+    // Pas de redirection vers dashboard
+    await expect(page).not.toHaveURL(/dashboard/)
+  })
+})

--- a/tests/e2e/devoirs.spec.ts
+++ b/tests/e2e/devoirs.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test'
+import { STUDENT, TEACHER, provisionStudent, loginAndWaitDashboard, navigateTo } from './helpers'
+
+/**
+ * Couverture : auth étudiant (manquant dans auth.spec.ts) + navigation devoirs.
+ *
+ * Prérequis : serveur démarré, base seedée avec promo id=1.
+ * La fixture STUDENT est provisionnée via l'API avant la suite.
+ */
+test.describe('Devoirs - flux étudiant', () => {
+  test.beforeAll(async () => {
+    await provisionStudent()
+  })
+
+  test('un étudiant peut se connecter et accéder au dashboard', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    await expect(page).toHaveURL(/dashboard/, { timeout: 10_000 })
+    // Le shell du dashboard est monté
+    await expect(page.locator('.dashboard-shell')).toBeVisible({ timeout: 10_000 })
+    // La session localStorage indique bien le rôle étudiant
+    await expect.poll(async () => {
+      return await page.evaluate(() => {
+        try {
+          const raw = localStorage.getItem('cc_session')
+          if (!raw) return null
+          return JSON.parse(raw).type
+        } catch { return null }
+      })
+    }, { timeout: 10_000 }).toBe('student')
+  })
+
+  test('un étudiant peut naviguer vers la page devoirs', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    await navigateTo(page, 'devoirs')
+    // La zone principale devoirs doit être rendue
+    await expect(page.locator('.devoirs-area')).toBeVisible({ timeout: 15_000 })
+    await expect(page.locator('.devoirs-content')).toBeVisible({ timeout: 15_000 })
+  })
+})
+
+/**
+ * Couverture : vue devoirs côté enseignant (accès + rendu du shell).
+ */
+test.describe('Devoirs - flux enseignant', () => {
+  test('un enseignant peut naviguer vers la page devoirs', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    await navigateTo(page, 'devoirs')
+    await expect(page.locator('.devoirs-area')).toBeVisible({ timeout: 15_000 })
+  })
+})

--- a/tests/e2e/messages.spec.ts
+++ b/tests/e2e/messages.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test'
+import { TEACHER, loginAndWaitDashboard, navigateTo } from './helpers'
+
+/**
+ * Couverture : navigation vers la section messages et rendu de la vue.
+ *
+ * Le flow messages existant n'est testé qu'en tant que sous-étape dans
+ * cross-promo-isolation.spec.ts (marqué .skip). Ce fichier fournit une
+ * couverture standalone qui tourne en CI.
+ */
+test.describe('Messages - navigation', () => {
+  test('un enseignant peut accéder à la section messages', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    await navigateTo(page, 'messages')
+    // La vue messages est bien montée (zone principale visible)
+    await expect(page.locator('.main-area')).toBeVisible({ timeout: 15_000 })
+  })
+
+  test('la vue messages affiche un en-tête de canal après sélection automatique', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    await navigateTo(page, 'messages')
+    // Un canal est sélectionné par défaut → l'en-tête de canal est rendu.
+    // On vérifie seulement la présence du header, pas son contenu exact
+    // (dépend du seed).
+    await expect(page.locator('#channel-header, .channel-header')).toBeVisible({ timeout: 15_000 })
+  })
+})

--- a/tsconfig.e2e.json
+++ b/tsconfig.e2e.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "lib": ["ES2020", "DOM"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "ignoreDeprecations": "5.0"
+  },
+  "include": ["tests/e2e/**/*.ts"]
+}


### PR DESCRIPTION
## Résumé

Cette PR ajoute 3 nouveaux fichiers de tests E2E Playwright couvrant les flows critiques manquants, identifiés après analyse de l'existant (`auth.spec.ts`, `demo-mode.spec.ts`, `cross-promo-isolation.spec.ts`).

### Flows couverts

| Fichier | Flow | Priorité |
|---|---|---|
| `devoirs.spec.ts` | **Auth étudiant** — login + vérification rôle `student` en localStorage | auth ⬆️ |
| `devoirs.spec.ts` | Navigation vers `/devoirs` + rendu `.devoirs-area` / `.devoirs-content` (étudiant & enseignant) | devoirs |
| `messages.spec.ts` | Navigation vers `/messages` + rendu `.main-area` + header de canal (enseignant) | messages |
| `access-control.spec.ts` | Redirect route guard `/booking` → `/dashboard` pour étudiant | auth/rôles |
| `access-control.spec.ts` | Redirect route guard `/fichiers` → `/dashboard` pour étudiant | auth/rôles |
| `access-control.spec.ts` | Enseignant accède à `/booking` sans redirection | auth/rôles |

### Ce qui n'était pas couvert avant

- Le login **étudiant** : `auth.spec.ts` ne testait que l'enseignant (`rfosse@cesi.fr`).
- Le rendu de la **vue devoirs** dans son intégralité (le test cross-promo était `test.skip`).
- La navigation **messages** en standalone (idem, uniquement dans le test skippé).
- Le **route guard** basé sur les rôles : aucun test ne vérifiait que les routes `teacher-only` bloquent réellement les étudiants.

### Fichier additionnel

- `tsconfig.e2e.json` : tsconfig dédié aux tests e2e (`lib: [ES2020, DOM]`, `skipLibCheck`) pour permettre `npx tsc --noEmit -p tsconfig.e2e.json`. Les tests existants et nouveaux passent sans erreur.

## Test plan

- [ ] `npx tsc --noEmit -p tsconfig.e2e.json` → 0 erreur
- [ ] Serveur démarré + seed : `npx playwright test devoirs.spec.ts`
- [ ] Serveur démarré + seed : `npx playwright test messages.spec.ts`
- [ ] Serveur démarré + seed : `npx playwright test access-control.spec.ts`
- [ ] Vérifier que les tests existants (`auth`, `demo-mode`) passent toujours

https://claude.ai/code/session_011yn5eSZMev3f3fpyqjLN5N

---
_Generated by [Claude Code](https://claude.ai/code/session_011yn5eSZMev3f3fpyqjLN5N)_