### PR TITLE
test(e2e): couverture des flows critiques manquants (auth étudiant, devoirs, messages, guard admin)

### DIFF
--- a/tests/e2e/admin-guard.spec.ts
+++ b/tests/e2e/admin-guard.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '@playwright/test'
+import { STUDENT, loginAndWaitDashboard, provisionStudent } from './helpers'
+
+/**
+ * Flow couvert :
+ *   - Un étudiant ne peut pas accéder à /admin
+ *   - Le guard Vue Router le redirige vers une autre section
+ *
+ * Ce test vérifie une propriété de sécurité fondamentale :
+ * les routes protégées par meta.requiredRole bloquent bien les rôles inférieurs.
+ */
+test.describe('Contrôle accès /admin', () => {
+  test.beforeAll(async () => {
+    await provisionStudent()
+  })
+
+  test('un étudiant est redirigé depuis /admin (guard requiredRole)', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+
+    // Tenter la navigation directe vers la route admin
+    await page.goto('/#/admin')
+    // Laisser le guard Vue Router traiter la navigation
+    await page.waitForTimeout(1_500)
+
+    // La route guard doit avoir redirigé : l'URL hash ne doit plus contenir /admin
+    await expect(page).not.toHaveURL(/#\/admin/, { timeout: 5_000 })
+  })
+})

--- a/tests/e2e/messages.spec.ts
+++ b/tests/e2e/messages.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test'
+import { TEACHER, loginAndWaitDashboard, navigateTo } from './helpers'
+
+/**
+ * Flows couverts :
+ *   - Enseignant accède à la vue messages (zone de chat visible)
+ *   - La sidebar liste au moins un canal ou DM (données réelles chargées)
+ */
+test.describe('Vue Messages', () => {
+
+  test('enseignant accède à la vue messages et voit la zone de chat', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    await navigateTo(page, 'messages')
+
+    // Une zone de mise en page messages (sidebar ou conteneur principal) est visible
+    const layout = page
+      .locator('aside, [class*="messages-view"], [class*="messages-layout"], [class*="chat-"]')
+      .first()
+    await expect(layout).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('la sidebar messages contient au moins un canal ou DM', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    await navigateTo(page, 'messages')
+
+    // Laisser les canaux se charger depuis l'API
+    await page.waitForTimeout(1_500)
+
+    const channelItem = page
+      .locator(
+        [
+          '[data-testid="channel-item"]',
+          '.channel-item',
+          '[class*="channel-name"]',
+          '[class*="sidebar"] li',
+          'aside li',
+        ].join(', '),
+      )
+      .first()
+
+    await expect(channelItem).toBeVisible({ timeout: 10_000 })
+  })
+})

--- a/tests/e2e/process.d.ts
+++ b/tests/e2e/process.d.ts
@@ -1,0 +1,5 @@
+// Déclaration minimale de process.env pour le type-check des tests e2e
+// sans dépendance à @types/node (non installé localement)
+declare const process: {
+  env: Record<string, string | undefined>
+}

--- a/tests/e2e/student-session.spec.ts
+++ b/tests/e2e/student-session.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from '@playwright/test'
+import {
+  STUDENT,
+  SEL,
+  loginAndWaitDashboard,
+  navigateTo,
+  provisionStudent,
+} from './helpers'
+
+/**
+ * Flows couverts :
+ *   - Connexion étudiant → dashboard (auth étudiant jamais testé ailleurs)
+ *   - Navigation vers la vue devoirs
+ *   - Déconnexion → retour formulaire login
+ */
+test.describe('Session étudiant', () => {
+  test.beforeAll(async () => {
+    // Crée l'étudiant de test via l'API si inexistant (idempotent)
+    await provisionStudent()
+  })
+
+  test('étudiant se connecte et arrive sur le dashboard', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    await expect(page).toHaveURL(/dashboard/)
+    // L'app-shell est monté : la navigation principale est visible
+    await expect(
+      page.locator('#app-shell, .app-shell, .app-columns'),
+    ).toBeVisible()
+  })
+
+  test('étudiant navigue vers la vue devoirs sans erreur fatale', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    await navigateTo(page, 'devoirs')
+    // navigateTo garantit déjà que l'URL contient "devoirs"
+    // La zone de contenu devoirs doit être montée
+    await expect(page.locator('.devoirs-area, .devoirs-content, [class*="devoir"]').first()).toBeVisible({
+      timeout: 10_000,
+    })
+  })
+
+  test('étudiant se déconnecte et voit le formulaire de connexion', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+
+    // Ouvrir le menu utilisateur si présent (avatar / bouton profil)
+    const avatarMenu = page
+      .locator(
+        '[data-testid="user-menu"], [data-testid="avatar"], .avatar-button, button[aria-label*="profil" i]',
+      )
+      .first()
+    if (await avatarMenu.isVisible({ timeout: 3_000 }).catch(() => false)) {
+      await avatarMenu.click()
+      await page.waitForTimeout(400)
+    }
+
+    const logoutBtn = page
+      .locator(
+        [
+          'button:has-text("Déconnexion")',
+          'button:has-text("Deconnexion")',
+          '[data-testid="logout"]',
+          'button[aria-label*="déconnexion" i]',
+          'button[aria-label*="logout" i]',
+        ].join(', '),
+      )
+      .first()
+
+    await expect(logoutBtn).toBeVisible({ timeout: 5_000 })
+    await logoutBtn.click()
+
+    // Après déconnexion, le formulaire de login réapparaît
+    await expect(page.locator(SEL.emailInput)).toBeVisible({ timeout: 10_000 })
+  })
+})

--- a/tests/e2e/tsconfig.json
+++ b/tests/e2e/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "ignoreDeprecations": "6.0",
+    "baseUrl": "/opt/node22/lib/node_modules",
+    "paths": {
+      "@playwright/test": ["playwright/test"]
+    }
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
## Résumé

Ajout de 3 fichiers de tests Playwright couvrant les flows critiques identifiés comme **non couverts** par les tests existants (`auth.spec.ts`, `demo-mode.spec.ts`, `cross-promo-isolation.spec.ts`).

---

## Flows couverts

### `tests/e2e/student-session.spec.ts` — Priorité : auth > devoirs
| Test | Description |
|------|-------------|
| ✅ étudiant se connecte et arrive sur le dashboard | Vérifie le login étudiant (seul le teacher était testé avant) |
| ✅ étudiant navigue vers la vue devoirs | Navigation + montage de `.devoirs-area` sans erreur fatale |
| ✅ étudiant se déconnecte et voit le formulaire de connexion | Logout complet → retour au formulaire login |

### `tests/e2e/messages.spec.ts` — Priorité : messages
| Test | Description |
|------|-------------|
| ✅ enseignant accède à la vue messages et voit la zone de chat | URL `/messages` + élément de mise en page visible |
| ✅ la sidebar messages contient au moins un canal ou DM | Données API chargées, au moins un item dans la sidebar |

### `tests/e2e/admin-guard.spec.ts` — Priorité : sécurité routes
| Test | Description |
|------|-------------|
| ✅ un étudiant est redirigé depuis /admin (guard requiredRole) | Vérifie que `meta.requiredRole: 'admin'` bloque un étudiant |

---

## Infrastructure

- **`tests/e2e/tsconfig.json`** : configuration TypeScript dédiée aux tests e2e (résolution vers le playwright global)
- **`tests/e2e/process.d.ts`** : déclaration minimale de `process.env` pour que `tsc --noEmit` passe sans `@types/node` local
- **`tsc --noEmit` : 0 erreur** sur les 3 nouveaux fichiers

## Patterns respectés

- Utilisation de `loginAndWaitDashboard()` et `navigateTo()` depuis `helpers.ts`
- `provisionStudent()` en `beforeAll` (idempotent, ignore 409)
- Multi-sélecteurs avec fallbacks CSS/data-testid pour robustesse CI
- Pas de duplication des tests existants

https://claude.ai/code/session_019m4ZgoiWCr64QWp3iP29b4

---
_Generated by [Claude Code](https://claude.ai/code/session_019m4ZgoiWCr64QWp3iP29b4)_