### PR TITLE
test(e2e): devoirs, messages et gardiens de routes

### DIFF
--- a/tests/e2e/devoirs.spec.ts
+++ b/tests/e2e/devoirs.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test'
+import { TEACHER, loginAndWaitDashboard, navigateTo } from './helpers'
+
+test.describe('Devoirs', () => {
+
+  test('enseignant : /devoirs se charge et affiche le bouton Nouveau devoir', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    await navigateTo(page, 'devoirs')
+    await expect(page.locator('.devoirs-area')).toBeVisible({ timeout: 10_000 })
+    // DevoirsHeader rend ce bouton uniquement pour les enseignants (v-if="appStore.isTeacher")
+    await expect(page.locator('button.dh-new')).toBeVisible({ timeout: 5_000 })
+  })
+
+  test('étudiant demo : /devoirs se charge, le bouton Nouveau devoir est absent', async ({ page }) => {
+    await page.goto('/#/demo')
+    await page.waitForSelector('button:has-text("Etudiant")', { timeout: 20_000 })
+    const [startRes] = await Promise.all([
+      page.waitForResponse(
+        (r) => r.url().includes('/api/demo/start') && r.request().method() === 'POST',
+        { timeout: 20_000 },
+      ),
+      page.click('button:has-text("Etudiant")'),
+    ])
+    expect(startRes.ok()).toBe(true)
+    await expect(page).toHaveURL(/dashboard/, { timeout: 15_000 })
+    await page.waitForSelector('#app-shell, .app-shell, .app-columns', { state: 'attached', timeout: 20_000 })
+
+    await navigateTo(page, 'devoirs')
+    await expect(page.locator('.devoirs-area')).toBeVisible({ timeout: 10_000 })
+    // Le bouton Nouveau est absent pour un étudiant
+    await expect(page.locator('button.dh-new')).not.toBeVisible()
+  })
+
+})

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -31,7 +31,7 @@ export async function getTeacherToken(): Promise<string> {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ email: TEACHER.email, password: TEACHER.password }),
   })
-  const data = await res.json()
+  const data = await res.json() as { ok: boolean; error?: string; data: { token: string } }
   if (!data.ok) throw new Error(`Teacher login failed: ${data.error}`)
   teacherToken = data.data.token
   return teacherToken!
@@ -50,7 +50,7 @@ export async function provisionStudent(): Promise<void> {
       promoId: STUDENT.promoId,
     }),
   })
-  const data = await res.json()
+  const data = await res.json() as { ok: boolean; error?: string }
   // Ignore if already exists (409 or "déjà utilisée" error)
   if (!data.ok && res.status !== 409 && !data.error?.includes('déjà')) {
     throw new Error(`Student provisioning failed: ${data.error}`)

--- a/tests/e2e/messages.spec.ts
+++ b/tests/e2e/messages.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test'
+import { TEACHER, loginAndWaitDashboard, navigateTo } from './helpers'
+
+test.describe('Messages', () => {
+
+  test('enseignant : /messages se charge et affiche la zone principale', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    await navigateTo(page, 'messages')
+    await expect(page.locator('#main-area')).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('sans canal actif, l\'état vide Bienvenue est affiché', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    // Effacer l'état de navigation persisté pour garantir qu'aucun canal n'est restauré
+    await page.evaluate(() => localStorage.removeItem('cc_nav_state'))
+    await page.goto('/#/messages')
+    await page.waitForSelector('#app-shell, .app-shell, .app-columns', { state: 'attached', timeout: 20_000 })
+    await expect(page.locator('#no-channel-hint')).toBeVisible({ timeout: 10_000 })
+  })
+
+})

--- a/tests/e2e/navigation-guards.spec.ts
+++ b/tests/e2e/navigation-guards.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect, type Page } from '@playwright/test'
+
+async function startDemoSession(page: Page, role: 'Etudiant' | 'Enseignant'): Promise<void> {
+  await page.goto('/#/demo')
+  await page.waitForSelector(`button:has-text("${role}")`, { timeout: 20_000 })
+  const [res] = await Promise.all([
+    page.waitForResponse(
+      (r) => r.url().includes('/api/demo/start') && r.request().method() === 'POST',
+      { timeout: 20_000 },
+    ),
+    page.click(`button:has-text("${role}")`),
+  ])
+  expect(res.ok()).toBe(true)
+  await expect(page).toHaveURL(/dashboard/, { timeout: 15_000 })
+  await page.waitForSelector('#app-shell, .app-shell, .app-columns', { state: 'attached', timeout: 20_000 })
+}
+
+test.describe('Gardiens de routes (role guards)', () => {
+
+  test('étudiant demo : /admin (rôle admin requis) redirige vers /dashboard', async ({ page }) => {
+    await startDemoSession(page, 'Etudiant')
+    await page.goto('/#/admin')
+    // Le router guard (beforeEach) redirige vers /dashboard si le rôle est insuffisant
+    await expect(page).toHaveURL(/dashboard/, { timeout: 10_000 })
+  })
+
+  test('enseignant demo : /admin (rôle admin requis) redirige vers /dashboard', async ({ page }) => {
+    await startDemoSession(page, 'Enseignant')
+    await page.goto('/#/admin')
+    await expect(page).toHaveURL(/dashboard/, { timeout: 10_000 })
+  })
+
+  test('étudiant demo : /booking (rôle teacher requis) redirige vers /dashboard', async ({ page }) => {
+    await startDemoSession(page, 'Etudiant')
+    await page.goto('/#/booking')
+    await expect(page).toHaveURL(/dashboard/, { timeout: 10_000 })
+  })
+
+})

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "lib": ["ES2020"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["e2e/**/*.ts"]
+}


### PR DESCRIPTION
## Résumé

Trois nouveaux specs Playwright couvrant les flows critiques non testés jusqu'ici (priorité : devoirs > messages > guards).

| Fichier | Tests | Flow couvert |
|---|---|---|
| `devoirs.spec.ts` | 2 | Navigation vers `/devoirs` — bouton *Nouveau* visible pour l'enseignant, absent pour l'étudiant démo |
| `messages.spec.ts` | 2 | `/messages` charge `#main-area` ; sans canal persisté, l'état vide `#no-channel-hint` s'affiche |
| `navigation-guards.spec.ts` | 3 | Route guards — étudiant démo bloqué sur `/admin` et `/booking` ; enseignant démo bloqué sur `/admin` |

**Flows NON dupliqués** : auth (login/invalid/teacher), demo-mode (student/teacher start, fallback), cross-promo isolation restent dans leurs specs existants.

### Détails techniques

- Chaque test de guard utilise la session démo (via `/api/demo/start`) pour éviter toute dépendance à des credentials fixes.
- Le test *état vide messages* efface `cc_nav_state` avant la navigation pour garantir l'absence de canal restauré depuis localStorage.
- `tests/tsconfig.json` ajouté pour permettre `npx tsc --project tests/tsconfig.json` en CI sans polluer le tsconfig principal.
- Fix de deux inférences `unknown` sur `res.json()` dans `helpers.ts` (annotations `as { ok, error, data }`) — seule modification d'un fichier existant.

## Plan de test

- [ ] `npx playwright test tests/e2e/devoirs.spec.ts` — 2 tests verts
- [ ] `npx playwright test tests/e2e/messages.spec.ts` — 2 tests verts
- [ ] `npx playwright test tests/e2e/navigation-guards.spec.ts` — 3 tests verts
- [ ] `npx tsc --project tests/tsconfig.json` — aucune erreur TypeScript
- [ ] Les specs existants (`auth`, `demo-mode`) restent verts (non modifiés hors fix helpers.ts)

https://claude.ai/code/session_01HbkPiY6ihEt99zVkYfDXfh

---
_Generated by [Claude Code](https://claude.ai/code/session_01HbkPiY6ihEt99zVkYfDXfh)_