### PR TITLE
test(e2e): role-guard, devoirs et messages (2026-05-14)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cursus",
-  "version": "2.282.0",
+  "version": "2.340.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cursus",
-      "version": "2.282.0",
+      "version": "2.340.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/tests/e2e/devoirs.spec.ts
+++ b/tests/e2e/devoirs.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test'
+import { TEACHER, STUDENT, loginAndWaitDashboard, navigateTo, provisionStudent } from './helpers'
+
+test.describe('Devoirs', () => {
+  test.beforeAll(async () => {
+    await provisionStudent()
+  })
+
+  test('enseignant : accède à la section devoirs et voit la vue principale', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    await navigateTo(page, 'devoirs')
+    await expect(page).toHaveURL(/devoirs/, { timeout: 10_000 })
+    // The view must render at least one heading or list container
+    await expect(
+      page.locator('h1, h2, [data-testid="devoirs-list"], .devoirs-list, main').first(),
+    ).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('étudiant : accède à ses devoirs et la page se charge sans erreur', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    await navigateTo(page, 'devoirs')
+    await expect(page).toHaveURL(/devoirs/, { timeout: 10_000 })
+    await expect(
+      page.locator('h1, h2, [data-testid="devoirs-list"], .devoirs-list, main').first(),
+    ).toBeVisible({ timeout: 10_000 })
+  })
+})

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -31,7 +31,7 @@ export async function getTeacherToken(): Promise<string> {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ email: TEACHER.email, password: TEACHER.password }),
   })
-  const data = await res.json()
+  const data = await res.json() as Record<string, any>
   if (!data.ok) throw new Error(`Teacher login failed: ${data.error}`)
   teacherToken = data.data.token
   return teacherToken!
@@ -50,7 +50,7 @@ export async function provisionStudent(): Promise<void> {
       promoId: STUDENT.promoId,
     }),
   })
-  const data = await res.json()
+  const data = await res.json() as Record<string, any>
   // Ignore if already exists (409 or "déjà utilisée" error)
   if (!data.ok && res.status !== 409 && !data.error?.includes('déjà')) {
     throw new Error(`Student provisioning failed: ${data.error}`)

--- a/tests/e2e/messages.spec.ts
+++ b/tests/e2e/messages.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test'
+import { TEACHER, loginAndWaitDashboard, navigateTo } from './helpers'
+
+test.describe('Messages', () => {
+  test('enseignant : accède à la section messages et voit la sidebar des canaux', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    await navigateTo(page, 'messages')
+    await expect(page).toHaveURL(/messages/, { timeout: 10_000 })
+    await expect(
+      page.locator('aside, [data-testid="channels-sidebar"], .channels-sidebar').first(),
+    ).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('enseignant : la liste des canaux contient au moins un canal', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    await navigateTo(page, 'messages')
+    // Allow channels to load from the API
+    await page.waitForTimeout(2_000)
+    const count = await page
+      .locator('[data-testid="channel-item"], .channel-item, aside li, .channels-list li')
+      .count()
+    expect(count).toBeGreaterThan(0)
+  })
+})

--- a/tests/e2e/role-guard.spec.ts
+++ b/tests/e2e/role-guard.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test'
+import { TEACHER, STUDENT, loginAndWaitDashboard, provisionStudent } from './helpers'
+
+/**
+ * Verifies that the Vue Router beforeEach guard (role-based) correctly
+ * redirects users who lack the required role, covering the teacher→/admin
+ * and student→teacher-only routes paths.
+ */
+test.describe('Garde de routes par rôle', () => {
+  test.beforeAll(async () => {
+    await provisionStudent()
+  })
+
+  test('enseignant : /admin redirige vers /dashboard (rôle admin requis)', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    // Teacher role is 'teacher', not 'admin' — guard must redirect
+    await page.goto('/#/admin')
+    await expect(page).toHaveURL(/dashboard/, { timeout: 10_000 })
+  })
+
+  test('étudiant : /booking redirige vers /dashboard (rôle enseignant requis)', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    await page.goto('/#/booking')
+    await expect(page).toHaveURL(/dashboard/, { timeout: 10_000 })
+  })
+
+  test('étudiant : /fichiers redirige vers /dashboard (rôle enseignant requis)', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    await page.goto('/#/fichiers')
+    await expect(page).toHaveURL(/dashboard/, { timeout: 10_000 })
+  })
+})

--- a/tests/e2e/tsconfig.json
+++ b/tests/e2e/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "node16",
+    "moduleResolution": "node16",
+    "lib": ["ES2020"],
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "noEmit": true
+  },
+  "include": ["./**/*.ts"]
+}


### PR DESCRIPTION
## Flows couverts

Trois fichiers de tests Playwright ajoutés pour combler les lacunes les plus critiques (priorité : auth > devoirs > messages).

### `role-guard.spec.ts` — Garde de routes par rôle (auth)
| Test | Description |
|---|---|
| Enseignant → `/admin` | Redirige vers `/dashboard` (rôle `admin` requis) |
| Étudiant → `/booking` | Redirige vers `/dashboard` (rôle `teacher` requis) |
| Étudiant → `/fichiers` | Redirige vers `/dashboard` (rôle `teacher` requis) |

Couvre le guard `beforeEach` du router Vue — non testé jusqu'ici malgré son rôle de barrière de sécurité principale.

### `devoirs.spec.ts` — Section devoirs
| Test | Description |
|---|---|
| Enseignant | Navigue vers `/devoirs`, vérifie qu'un élément principal est visible |
| Étudiant provisionné | Même vérification côté étudiant, sans erreur serveur |

### `messages.spec.ts` — Section messages
| Test | Description |
|---|---|
| Enseignant (sidebar) | Navigue vers `/messages`, vérifie que la sidebar des canaux est présente |
| Enseignant (canaux) | Vérifie qu'au moins un canal est listé après chargement |

## Autres changements

- `tests/e2e/tsconfig.json` — tsconfig dédié pour `npx tsc --noEmit` sur les specs E2E
- `tests/e2e/helpers.ts` — deux annotations de type (`as Record<string, any>`) pour corriger des erreurs strict-mode préexistantes sur `res.json()`

## Tests non dupliqués

Les flows existants (`auth.spec.ts`, `demo-mode.spec.ts`, `cross-promo-isolation.spec.ts`) ne sont pas rejoués.

https://claude.ai/code/session_01LYY1hcb91JhMLjC6pTUXnF

---
_Generated by [Claude Code](https://claude.ai/code/session_01LYY1hcb91JhMLjC6pTUXnF)_