### PR TITLE
test(e2e): couverture devoirs + gardes de route (auth étudiant, vue élève/prof, access control)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cursus",
-  "version": "2.340.0",
+  "version": "2.341.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cursus",
-      "version": "2.340.0",
+      "version": "2.341.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/tests/e2e/devoirs.spec.ts
+++ b/tests/e2e/devoirs.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test'
+import { TEACHER, STUDENT, loginAndWaitDashboard, navigateTo, provisionStudent } from './helpers'
+
+test.describe('Devoirs', () => {
+
+  test.beforeAll(async () => {
+    await provisionStudent()
+  })
+
+  test('étudiant se connecte et est redirigé vers le tableau de bord', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    await expect(page).toHaveURL(/dashboard/, { timeout: 10_000 })
+  })
+
+  test('étudiant accède à la page devoirs et voit la vue élève', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    await navigateTo(page, 'devoirs')
+    // Le conteneur principal est bien monté
+    await expect(page.locator('.devoirs-area')).toBeVisible({ timeout: 15_000 })
+    // La vue élève est affichée (accueil ou skeleton de chargement)
+    await expect(page.locator('.dv-page, .devoirs-list')).toBeVisible({ timeout: 15_000 })
+    // La toolbar enseignant ne doit pas s'afficher pour un étudiant
+    await expect(page.locator('.dh-toolbar')).not.toBeVisible()
+  })
+
+  test('enseignant accède à la page devoirs et voit la vue enseignant', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    await navigateTo(page, 'devoirs')
+    await expect(page.locator('.devoirs-area')).toBeVisible({ timeout: 15_000 })
+    // La toolbar enseignant (chips "À traiter" / "Brouillons") est spécifique au prof
+    await expect(page.locator('.dh-toolbar, .btn-cta')).toBeVisible({ timeout: 20_000 })
+    // Le donut de progression élève ne doit pas s'afficher pour un enseignant
+    await expect(page.locator('.sdv-donut')).not.toBeVisible()
+  })
+
+})

--- a/tests/e2e/route-guards.spec.ts
+++ b/tests/e2e/route-guards.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test'
+import { STUDENT, loginAndWaitDashboard, provisionStudent } from './helpers'
+
+test.describe('Gardes de route (contrôle d\'accès par rôle)', () => {
+
+  test.beforeAll(async () => {
+    await provisionStudent()
+  })
+
+  test('un étudiant est redirigé de /admin vers /dashboard', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    // Tentative d'accès direct à la route admin-only (requiredRole: 'admin')
+    await page.goto('/#/admin')
+    // Le garde de route doit rediriger vers le dashboard
+    await expect(page).toHaveURL(/dashboard/, { timeout: 10_000 })
+    // L'interface admin ne doit jamais s'afficher
+    await expect(page.locator('.admin-view')).not.toBeVisible()
+  })
+
+  test('un étudiant est redirigé de /booking vers /dashboard', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    // Tentative d'accès à la route réservée aux enseignants (requiredRole: 'teacher')
+    await page.goto('/#/booking')
+    await expect(page).toHaveURL(/dashboard/, { timeout: 10_000 })
+  })
+
+})


### PR DESCRIPTION
## Flows E2E couverts

### `devoirs.spec.ts` — 3 tests
| Test | Description |
|------|-------------|
| **auth étudiant** | `STUDENT` se connecte via le formulaire et est redirigé vers `/dashboard` — comble le manque dans `auth.spec.ts` qui ne testait que le cas enseignant |
| **vue élève** | Après login étudiant, navigation vers `/devoirs` → `.devoirs-area` visible + vue élève (`.dv-page` / `.devoirs-list`) présente, toolbar enseignant (`.dh-toolbar`) absente |
| **vue enseignant** | Après login enseignant, navigation vers `/devoirs` → toolbar enseignant (`.dh-toolbar` / `.btn-cta`) visible, donut progression élève (`.sdv-donut`) absent |

### `route-guards.spec.ts` — 2 tests
| Test | Description |
|------|-------------|
| **/admin bloqué étudiant** | Étudiant tente `/#/admin` (requiredRole: `admin`) → `beforeEach` guard redirige vers `/dashboard`, `.admin-view` n'est jamais affiché |
| **/booking bloqué étudiant** | Étudiant tente `/#/booking` (requiredRole: `teacher`) → redirigé vers `/dashboard` |

## Flows intentionnellement non couverts
- **messages** : aucune donnée de channel nécessite un seed manuel non garanti en CI
- **admin accès** : `rfosse@cesi.fr` est promu admin par la migration v42 — un test "admin peut accéder" dépendrait d'une invariant de seed fragile
- **cross-promo** : déjà présent mais skippé (`cross-promo-isolation.spec.ts`)

## Checklist technique
- [x] `provisionStudent()` appelé en `beforeAll` pour les deux fichiers
- [x] Aucune duplication avec `auth.spec.ts` (login prof) ni `demo-mode.spec.ts`
- [x] TypeScript valide (`tsc --noEmit` sans erreur)
- [x] Sélecteurs stables : classes CSS métier (`.devoirs-area`, `.dh-toolbar`, `.sdv-donut`, `.admin-view`) plutôt que texte susceptible d'être reformulé
- [x] Timeouts adaptés au CI (15–20 s pour le chargement des données async)

---
_Generated by [Claude Code](https://claude.ai/code/session_016YBpNgm2rVbvQig8gFDiNw)_