### PR TITLE
test(e2e): student-auth RBAC + devoirs + messages (auto-generated)

### DIFF
--- a/tests/e2e/devoirs.spec.ts
+++ b/tests/e2e/devoirs.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test'
+import { TEACHER, STUDENT, loginAndWaitDashboard, navigateTo, provisionStudent } from './helpers'
+
+test.describe('Section Devoirs', () => {
+  test.beforeAll(async () => {
+    await provisionStudent()
+  })
+
+  test('enseignant navigue vers les devoirs et voit la vue teacher', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    await navigateTo(page, 'devoirs')
+    await expect(page).toHaveURL(/devoirs/, { timeout: 10_000 })
+    // La vue teacher devoirs se monte : au moins un titre ou container est visible
+    await expect(page.locator('h1, h2, h3, .devoirs-header').first()).toBeVisible({ timeout: 12_000 })
+  })
+
+  test('étudiant navigue vers les devoirs et voit sa vue', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    await navigateTo(page, 'devoirs')
+    await expect(page).toHaveURL(/devoirs/, { timeout: 10_000 })
+    // La vue étudiant se monte sans crash (main ou section est visible)
+    await expect(page.locator('main, section, .devoirs-view').first()).toBeVisible({ timeout: 12_000 })
+  })
+
+  test('enseignant accède à /exam-review (route protégée teacher)', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    // /exam-review/:travailId est réservé au prof — l'accès ne doit PAS rediriger vers /dashboard
+    await page.goto('/#/exam-review/9999')
+    await expect(page).toHaveURL(/exam-review/, { timeout: 8_000 })
+  })
+})

--- a/tests/e2e/messages.spec.ts
+++ b/tests/e2e/messages.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test'
+import { TEACHER, loginAndWaitDashboard, navigateTo } from './helpers'
+
+test.describe('Section Messages', () => {
+  test('enseignant navigue vers les messages et voit la vue', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    await navigateTo(page, 'messages')
+    await expect(page).toHaveURL(/messages/, { timeout: 10_000 })
+    // La vue messages se monte : sidebar ou liste de canaux visible
+    await expect(page.locator('aside, .messages-view, [role="navigation"]').first()).toBeVisible({ timeout: 12_000 })
+  })
+
+  test('la dernière route est persistée dans localStorage après navigation', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    await navigateTo(page, 'messages')
+    // Le afterEach du router stocke { path: '/messages' } sous la clé cc_last_route
+    const stored = await page.evaluate(() => localStorage.getItem('cc_last_route'))
+    expect(stored).not.toBeNull()
+    const parsed = JSON.parse(stored as string) as { path: string }
+    expect(parsed.path).toBe('/messages')
+  })
+
+  test('la route est mise à jour après une deuxième navigation', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    await navigateTo(page, 'messages')
+    await navigateTo(page, 'documents')
+    // Après navigation vers documents, cc_last_route doit pointer sur /documents
+    const stored = await page.evaluate(() => localStorage.getItem('cc_last_route'))
+    const parsed = JSON.parse(stored as string) as { path: string }
+    expect(parsed.path).toBe('/documents')
+  })
+})

--- a/tests/e2e/student-auth.spec.ts
+++ b/tests/e2e/student-auth.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test'
+import { STUDENT, provisionStudent, loginAndWaitDashboard } from './helpers'
+
+test.describe('Authentification étudiant + gardes de route RBAC', () => {
+  test.beforeAll(async () => {
+    await provisionStudent()
+  })
+
+  test('connecte un étudiant et affiche le dashboard', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    await expect(page).toHaveURL(/dashboard/, { timeout: 10_000 })
+  })
+
+  test('bloque l\'accès étudiant à /admin (rôle insuffisant)', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    // /admin requiert meta.requiredRole: 'admin' — le guard redirige vers /dashboard
+    await page.goto('/#/admin')
+    await expect(page).toHaveURL(/dashboard/, { timeout: 8_000 })
+  })
+
+  test('bloque l\'accès étudiant à /booking (route enseignant)', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    // /booking requiert meta.requiredRole: 'teacher' — le guard redirige vers /dashboard
+    await page.goto('/#/booking')
+    await expect(page).toHaveURL(/dashboard/, { timeout: 8_000 })
+  })
+
+  test('bloque l\'accès étudiant à /fichiers (route enseignant)', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    // /fichiers requiert meta.requiredRole: 'teacher'
+    await page.goto('/#/fichiers')
+    await expect(page).toHaveURL(/dashboard/, { timeout: 8_000 })
+  })
+})

--- a/tsconfig.e2e.json
+++ b/tsconfig.e2e.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "lib": ["ES2020", "DOM"],
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["tests/e2e/**/*.ts"]
+}


### PR DESCRIPTION
## Résumé

Ajout de 3 nouveaux fichiers de tests Playwright E2E couvrant les flows critiques non testés, identifiés par analyse du coverage existant (auth enseignant, demo mode, cross-promo skippé).

## Flows couverts

### `tests/e2e/student-auth.spec.ts` — Auth étudiant + gardes RBAC
- Login étudiant valide → dashboard (le seul test auth existant ne couvre que l'enseignant)
- Accès `/admin` en tant qu'étudiant → redirigé vers `/dashboard` (guard `requiredRole: 'admin'`)
- Accès `/booking` en tant qu'étudiant → redirigé vers `/dashboard` (guard `requiredRole: 'teacher'`)
- Accès `/fichiers` en tant qu'étudiant → redirigé vers `/dashboard` (guard `requiredRole: 'teacher'`)

### `tests/e2e/devoirs.spec.ts` — Section Devoirs
- Enseignant navigue vers `/devoirs` via NavRail → vue teacher montée
- Étudiant navigue vers `/devoirs` via NavRail → vue student montée sans crash
- Enseignant accède à `/exam-review/:id` (route teacher-only) → pas de redirect, composant chargé

### `tests/e2e/messages.spec.ts` — Section Messages + persistance de route
- Enseignant navigue vers `/messages` → vue montée (sidebar/liste canaux visible)
- Après navigation, `localStorage.cc_last_route` contient `{ path: '/messages' }` (router `afterEach`)
- Après deux navigations successives, `cc_last_route` reflète la dernière route visitée (`/documents`)

## Infrastructure
- `tsconfig.e2e.json` : config TypeScript dédiée pour `npx tsc --noEmit --project tsconfig.e2e.json` (résout `@playwright/test` et les types Node sans toucher au tsconfig principal)

## Test plan
- [ ] `npx playwright test tests/e2e/student-auth.spec.ts` passe (nécessite server:dev + seed)
- [ ] `npx playwright test tests/e2e/devoirs.spec.ts` passe
- [ ] `npx playwright test tests/e2e/messages.spec.ts` passe
- [ ] `npx tsc --noEmit --project tsconfig.e2e.json` → 0 erreur

https://claude.ai/code/session_01Gp69XwL9SN87FM5yq2gj4S

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gp69XwL9SN87FM5yq2gj4S)_