### PR TITLE
test(e2e): student-flows et messages — 5 nouveaux parcours critiques

### DIFF
--- a/tests/e2e/messages.spec.ts
+++ b/tests/e2e/messages.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test'
+import { loginAndWaitDashboard, navigateTo, TEACHER } from './helpers'
+
+test.describe('Vue messages', () => {
+  test("la vue messages se charge correctement pour un enseignant", async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    await navigateTo(page, 'messages')
+    await expect(page.locator('#main-area')).toBeVisible({ timeout: 10_000 })
+  })
+
+  test("la zone principale affiche l'en-tête de canal ou le hint de sélection", async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    await page.goto('/#/messages')
+    await expect(page.locator('#main-area')).toBeVisible({ timeout: 10_000 })
+    // Un canal peut être auto-sélectionné (#channel-header) ou pas (#no-channel-hint)
+    await expect(page.locator('#channel-header, #no-channel-hint')).toBeVisible({ timeout: 10_000 })
+  })
+})

--- a/tests/e2e/student-flows.spec.ts
+++ b/tests/e2e/student-flows.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from '@playwright/test'
+import { loginAndWaitDashboard, navigateTo, provisionStudent, STUDENT } from './helpers'
+
+test.describe('Parcours étudiant', () => {
+  test.beforeAll(async () => {
+    await provisionStudent()
+  })
+
+  test('un étudiant peut se connecter et accéder au dashboard', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    await expect(page.locator('#app-shell, .app-shell, .app-columns')).toBeAttached()
+  })
+
+  test("la route /admin est inaccessible à un étudiant et redirige vers /dashboard", async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    await page.goto('/#/admin')
+    // router/index.ts:89 — guard redirige vers /dashboard si requiredRole non satisfait
+    await expect(page).toHaveURL(/dashboard/, { timeout: 5_000 })
+  })
+
+  test("un étudiant peut naviguer vers la vue devoirs", async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    await navigateTo(page, 'devoirs')
+    await expect(page.locator('.devoirs-area, .devoirs-content')).toBeVisible({ timeout: 10_000 })
+  })
+})


### PR DESCRIPTION
## Contexte

Les tests E2E existants (`auth.spec.ts`, `demo-mode.spec.ts`) ne couvraient que le login enseignant et le mode démo. Cette PR ajoute 2 fichiers de spec couvrant les parcours **étudiant**, **guard admin**, **devoirs** et **messages**.

## Flows couverts

### `tests/e2e/student-flows.spec.ts` — Parcours étudiant (priorité : auth + devoirs)

| Test | Scénario |
|------|----------|
| Connexion étudiant | `provisionStudent()` + login → `#app-shell` attaché |
| Guard route `/admin` | Étudiant navigue vers `/#/admin` → redirigé vers `/dashboard` (router/index.ts:89) |
| Navigation devoirs | Étudiant clique sur devoirs → `.devoirs-area` ou `.devoirs-content` visible |

### `tests/e2e/messages.spec.ts` — Vue messages (priorité : messages)

| Test | Scénario |
|------|----------|
| Chargement vue | Enseignant navigue vers messages → `#main-area` visible |
| État canal | `#channel-header` (canal auto-sélectionné) **ou** `#no-channel-hint` visible |

## Ce qui n'est PAS dupliqué

- Login enseignant → déjà dans `auth.spec.ts`
- Demo mode → déjà dans `demo-mode.spec.ts`
- Isolation inter-promo → déjà dans `cross-promo-isolation.spec.ts` (skippé)

## Vérification

```
npx tsc --noEmit  # aucune erreur dans les nouveaux fichiers
```

Seul avertissement existant : dépréciation `baseUrl` dans `tsconfig.json` (non introduit par cette PR).

https://claude.ai/code/session_018h77bjCvmPVP9tt64NMv67

---
_Generated by [Claude Code](https://claude.ai/code/session_018h77bjCvmPVP9tt64NMv67)_