### PR TITLE
test(e2e): devoirs, messages et contrôle d'accès admin

### DIFF
--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test'
+import { provisionStudent, loginAndWaitDashboard, STUDENT } from './helpers'
+
+test.describe("Contrôle d'accès Admin", () => {
+  test.beforeAll(async () => {
+    await provisionStudent()
+  })
+
+  test("étudiant redirigé hors de /admin (rôle insuffisant)", async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    // requiredRole: 'admin' — un étudiant doit être renvoyé au dashboard
+    await page.goto('/#/admin')
+    await expect(page).not.toHaveURL(/\/admin/, { timeout: 10_000 })
+    // L'interface admin ne doit pas être montée
+    await expect(page.locator('.admin-view')).not.toBeVisible()
+  })
+
+  test("accès à /admin sans session redirige hors de la route", async ({ page }) => {
+    // Contexte vierge : aucun cc_session en localStorage
+    await page.goto('/#/admin')
+    // Le garde de route doit empêcher l'affichage de l'administration
+    await expect(page).not.toHaveURL(/\/admin/, { timeout: 10_000 })
+    await expect(page.locator('.admin-view')).not.toBeVisible()
+  })
+})

--- a/tests/e2e/devoirs.spec.ts
+++ b/tests/e2e/devoirs.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test'
+import { provisionStudent, loginAndWaitDashboard, navigateTo, TEACHER, STUDENT } from './helpers'
+
+test.describe('Devoirs', () => {
+  test.beforeAll(async () => {
+    await provisionStudent()
+  })
+
+  test('étudiant accède à la liste de devoirs', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    await navigateTo(page, 'devoirs')
+    await expect(page).toHaveURL(/devoirs/, { timeout: 10_000 })
+    await expect(page.locator('.devoirs-area')).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('enseignant accède à la vue devoirs enseignant', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    await navigateTo(page, 'devoirs')
+    await expect(page).toHaveURL(/devoirs/, { timeout: 10_000 })
+    await expect(page.locator('.devoirs-area')).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('exam-review redirige un étudiant vers le dashboard (garde de rôle)', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    // La route /exam-review/:id requiert requiredRole: 'teacher'
+    await page.goto('/#/exam-review/1')
+    await expect(page).toHaveURL(/dashboard/, { timeout: 10_000 })
+    // Vérification : la vue devoirs n'est pas affichée
+    await expect(page.locator('.devoirs-area')).not.toBeVisible()
+  })
+})

--- a/tests/e2e/messages.spec.ts
+++ b/tests/e2e/messages.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test'
+import { provisionStudent, loginAndWaitDashboard, navigateTo, TEACHER, STUDENT } from './helpers'
+
+test.describe('Messages', () => {
+  test.beforeAll(async () => {
+    await provisionStudent()
+  })
+
+  test('la vue messages charge la structure principale', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    await navigateTo(page, 'messages')
+    await expect(page).toHaveURL(/messages/, { timeout: 10_000 })
+    // La zone centrale (#main-area) doit être montée
+    await expect(page.locator('#main-area')).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('un canal actif ou le hint vide est affiché après navigation', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    await navigateTo(page, 'messages')
+    await expect(page).toHaveURL(/messages/, { timeout: 10_000 })
+    // Selon que l'étudiant a des canaux : header canal OU hint "aucun canal sélectionné"
+    const channelHeader = page.locator('#channel-header')
+    const noChannelHint = page.locator('#no-channel-hint')
+    await expect(channelHeader.or(noChannelHint)).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('enseignant : bouton recherche présent dans le header du canal', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    await navigateTo(page, 'messages')
+    await expect(page).toHaveURL(/messages/, { timeout: 10_000 })
+    // Si un canal est actif, le bouton de recherche (#btn-search) doit être présent
+    const channelHeader = page.locator('#channel-header')
+    const hasChannel = await channelHeader.isVisible({ timeout: 5_000 }).catch(() => false)
+    if (hasChannel) {
+      await expect(page.locator('#btn-search')).toBeVisible({ timeout: 5_000 })
+    }
+  })
+})


### PR DESCRIPTION
## Contexte

Les tests E2E existants couvraient : authentification, mode démo, et isolation cross-promo (skipped). Trois flows critiques n'étaient pas couverts.

## Flows ajoutés

### `devoirs.spec.ts` (priorité 1)
- **Étudiant** navigue vers `/devoirs` et voit `.devoirs-area` monté
- **Enseignant** navigue vers `/devoirs` et voit la vue enseignant
- **Garde de rôle** : un étudiant accédant à `/#/exam-review/:id` (`requiredRole: 'teacher'`) est redirigé vers `/dashboard`

### `messages.spec.ts` (priorité 2)
- La structure `#main-area` est visible après navigation vers `/messages`
- Vérification robuste : soit `#channel-header` (canal actif) soit `#no-channel-hint` (état vide) est affiché
- Bouton de recherche `#btn-search` présent dans le header quand un canal est actif (vue enseignant)

### `admin.spec.ts` (priorité 3)
- Un étudiant accédant à `/#/admin` (`requiredRole: 'admin'`) est redirigé — `.admin-view` non monté
- Un utilisateur sans session est également bloqué et redirigé hors de `/admin`

## Validation

```
npx tsc --noEmit  →  0 erreur (avertissement baseUrl pré-existant non lié)
```

Tous les tests suivent les patterns du projet : `loginAndWaitDashboard`, `navigateTo`, sélecteurs `#id` / `.class`, `toHaveURL` avec regex.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NRsG6b5tg2PZYEiveTULC6)_