### PR TITLE
test(e2e): guards de route, devoirs étudiant, messages enseignant

### DIFF
--- a/tests/e2e/devoirs-student.spec.ts
+++ b/tests/e2e/devoirs-student.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test'
+import { STUDENT, loginAndWaitDashboard, navigateTo, provisionStudent } from './helpers'
+
+/**
+ * Devoirs - Parcours étudiant
+ *
+ * Vérifie que l'étudiant peut naviguer vers la section Devoirs,
+ * que la vue StudentDevoirsView se monte correctement, et que les
+ * alias de route fonctionnent.
+ *
+ * Prérequis : le compte étudiant de test est créé via provisionStudent()
+ * (idempotent — pas d'effet si le compte existe déjà).
+ */
+
+test.describe('Devoirs - Étudiant', () => {
+
+  test.beforeAll(async () => {
+    await provisionStudent()
+  })
+
+  test('navigation vers /devoirs depuis le dashboard → vue devoirs visible', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    await navigateTo(page, 'devoirs')
+    await expect(page).toHaveURL(/devoirs/, { timeout: 15_000 })
+    // DevoirsView monte toujours .devoirs-area quelle que soit la liste des travaux
+    await expect(page.locator('.devoirs-area')).toBeVisible({ timeout: 15_000 })
+  })
+
+  test('alias /travaux redirige transparentement vers /devoirs', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    // /travaux est un alias déclaré dans le router (redirect: '/devoirs')
+    await page.goto('/#/travaux')
+    await expect(page).toHaveURL(/devoirs/, { timeout: 10_000 })
+  })
+
+  test('retour au dashboard depuis les devoirs', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    await navigateTo(page, 'devoirs')
+    await expect(page).toHaveURL(/devoirs/, { timeout: 15_000 })
+    await navigateTo(page, 'dashboard')
+    await expect(page).toHaveURL(/dashboard/, { timeout: 10_000 })
+  })
+
+})

--- a/tests/e2e/messages-teacher.spec.ts
+++ b/tests/e2e/messages-teacher.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test'
+import { TEACHER, loginAndWaitDashboard, navigateTo } from './helpers'
+
+/**
+ * Messages - Parcours enseignant
+ *
+ * Vérifie que l'enseignant peut accéder à la section Messages et
+ * que la zone principale (#main-area) se monte correctement.
+ * En contexte navigateur frais (localStorage vide), aucun salon
+ * n'est mémorisé : soit un salon est auto-sélectionné via l'API,
+ * soit l'état vide (hint desktop #no-channel-hint) s'affiche.
+ */
+
+test.describe('Messages - Enseignant', () => {
+
+  test('navigation vers /messages charge la zone principale', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    await navigateTo(page, 'messages')
+    await expect(page).toHaveURL(/messages/, { timeout: 15_000 })
+    // #main-area est le conteneur racine de MessagesView, toujours présent
+    await expect(page.locator('#main-area')).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('etat initial : header canal ou hint desktop est visible', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    await navigateTo(page, 'messages')
+    await expect(page).toHaveURL(/messages/, { timeout: 15_000 })
+
+    // En contexte frais (pas de salon sauvegardé), deux cas possibles :
+    //   1. Un salon est chargé automatiquement → #channel-header visible
+    //   2. Aucun salon sélectionné → #no-channel-hint visible
+    // Les deux sont des états valides ; on vérifie qu'au moins l'un s'affiche.
+    const channelHeaderVisible = await page
+      .locator('#channel-header')
+      .isVisible({ timeout: 5_000 })
+      .catch(() => false)
+
+    if (!channelHeaderVisible) {
+      await expect(page.locator('#no-channel-hint')).toBeVisible({ timeout: 8_000 })
+    }
+  })
+
+  test('retour au dashboard depuis les messages', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    await navigateTo(page, 'messages')
+    await expect(page).toHaveURL(/messages/, { timeout: 15_000 })
+    await navigateTo(page, 'dashboard')
+    await expect(page).toHaveURL(/dashboard/, { timeout: 10_000 })
+  })
+
+})

--- a/tests/e2e/route-guards.spec.ts
+++ b/tests/e2e/route-guards.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test'
+import { TEACHER, STUDENT, login, loginAndWaitDashboard, provisionStudent } from './helpers'
+
+/**
+ * Guards de route : contrôle d'accès par rôle
+ *
+ * Vérifie que le beforeEach du router (src/renderer/src/router/index.ts)
+ * refuse l'accès aux routes restreintes et redirige vers /dashboard.
+ *
+ * Flux couverts :
+ *  - Enseignant → /admin (role 'admin' requis) → dashboard
+ *  - Enseignant → route inconnue (catch-all) → dashboard
+ *  - Étudiant → /booking (role 'teacher' requis) → dashboard
+ *  - Étudiant → /fichiers (role 'teacher' requis) → dashboard
+ *  - Étudiant → /exam-review/:id (role 'teacher' requis) → dashboard
+ */
+
+test.describe('Guards de route - Enseignant', () => {
+
+  test('acces a /admin refuse (role admin requis) → redirection dashboard', async ({ page }) => {
+    await login(page, TEACHER.email, TEACHER.password)
+    await expect(page).toHaveURL(/dashboard/, { timeout: 10_000 })
+    await page.goto('/#/admin')
+    await expect(page).toHaveURL(/dashboard/, { timeout: 10_000 })
+  })
+
+  test('route inconnue → redirection dashboard (catch-all router)', async ({ page }) => {
+    await login(page, TEACHER.email, TEACHER.password)
+    await expect(page).toHaveURL(/dashboard/, { timeout: 10_000 })
+    await page.goto('/#/cette-route-nexiste-pas-xyz')
+    await expect(page).toHaveURL(/dashboard/, { timeout: 10_000 })
+  })
+
+})
+
+test.describe('Guards de route - Étudiant', () => {
+
+  test.beforeAll(async () => {
+    await provisionStudent()
+  })
+
+  test('acces a /booking refuse (role teacher requis) → redirection dashboard', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    await page.goto('/#/booking')
+    await expect(page).toHaveURL(/dashboard/, { timeout: 10_000 })
+  })
+
+  test('acces a /fichiers refuse (role teacher requis) → redirection dashboard', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    await page.goto('/#/fichiers')
+    await expect(page).toHaveURL(/dashboard/, { timeout: 10_000 })
+  })
+
+  test('acces a /exam-review refuse (role teacher requis) → redirection dashboard', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    await page.goto('/#/exam-review/1')
+    await expect(page).toHaveURL(/dashboard/, { timeout: 10_000 })
+  })
+
+})


### PR DESCRIPTION
## Résumé

Ajout de 3 fichiers de tests Playwright E2E couvrant des parcours critiques **non couverts** par les tests existants (`auth.spec.ts`, `demo-mode.spec.ts`, `cross-promo-isolation.spec.ts`).

### Flows couverts

| Fichier | Flows testés | Priorité |
|---|---|---|
| `route-guards.spec.ts` | Enseignant → `/admin` → redirection dashboard ; étudiant → `/booking`, `/fichiers`, `/exam-review/:id` → redirection dashboard ; catch-all route inconnue | 🔴 Sécurité |
| `devoirs-student.spec.ts` | Navigation étudiant vers `/devoirs` ; alias `/travaux` → `/devoirs` ; aller-retour dashboard ↔ devoirs | 🟠 Devoirs |
| `messages-teacher.spec.ts` | Chargement `#main-area` sur `/messages` ; gestion état vide (hint desktop) vs canal auto-sélectionné ; aller-retour dashboard ↔ messages | 🟡 Messages |

### Détails techniques

- **`route-guards.spec.ts`** valide le guard `router.beforeEach` qui lit `cc_session.type` en localStorage et redirige vers `/dashboard` si le rôle est insuffisant. C'est le seul test de sécurité d'accès par rôle dans la suite.
- **`devoirs-student.spec.ts`** utilise `provisionStudent()` (helper idempotent existant) en `beforeAll`. Couvre la vue `StudentDevoirsView` et l'alias de route `/travaux`.
- **`messages-teacher.spec.ts`** est robuste aux deux états initiaux : canal auto-sélectionné (via API) ou état vide (`#no-channel-hint`), selon que l'API répond ou non en CI.

### Patterns réutilisés

- `login()` / `loginAndWaitDashboard()` / `navigateTo()` / `provisionStudent()` depuis `helpers.ts`
- Même structure `test.describe` + `test.beforeAll` que les tests existants
- Sélecteurs CSS stables (IDs et classes de composants Vue : `#main-area`, `#channel-header`, `.devoirs-area`)

## Plan de test

- [ ] `npm run test:e2e` avec serveur + seed en local
- [ ] Vérifier que les 3 `describe` s'affichent dans le rapport Playwright
- [ ] Vérifier qu'aucun test duplique un cas de `auth.spec.ts` ou `demo-mode.spec.ts`


---
_Generated by [Claude Code](https://claude.ai/code/session_01T4VXQXRTegzYN7XJAfAKbs)_