### PR TITLE
test(e2e): couvre login étudiant, vue devoirs et navigation messages

### DIFF
--- a/tests/e2e/messages.spec.ts
+++ b/tests/e2e/messages.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test'
+import { TEACHER, loginAndWaitDashboard, navigateTo } from './helpers'
+
+test.describe('Messages – navigation et interface', () => {
+
+  test("l'enseignant accède à la section messages et voit la liste des canaux", async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    await navigateTo(page, 'messages')
+    // Conteneur racine de MessagesView.vue (toujours rendu quelle que soit la sélection)
+    await expect(page.locator('#main-area')).toBeVisible({ timeout: 15_000 })
+    // L'en-tête de la section "Canaux" est rendu par Sidebar.vue (bloc v-else sur la route messages)
+    // après la fin du chargement des données (skeleton → liste)
+    await expect(page.locator('#sidebar-channels-header')).toBeVisible({ timeout: 15_000 })
+  })
+
+})

--- a/tests/e2e/student.spec.ts
+++ b/tests/e2e/student.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test'
+import { STUDENT, provisionStudent, loginAndWaitDashboard, navigateTo } from './helpers'
+
+test.describe('Étudiant – authentification et devoirs', () => {
+
+  test.beforeAll(async () => {
+    await provisionStudent()
+  })
+
+  test('un étudiant peut se connecter et accéder au dashboard', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    await expect(page).toHaveURL(/dashboard/, { timeout: 10_000 })
+    // Le shell applicatif doit être monté (même vérification que le test teacher dans auth.spec.ts)
+    await expect(page.locator('#app-shell, .app-shell, .app-columns')).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('la page /devoirs affiche la vue étudiant sans le bouton enseignant "Nouveau devoir"', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    await navigateTo(page, 'devoirs')
+    // Conteneur racine rendu par DevoirsView.vue
+    await expect(page.locator('.devoirs-area')).toBeVisible({ timeout: 15_000 })
+    // Le bouton "Nouveau devoir" est v-if="appStore.isTeacher" dans DevoirsHeader.vue —
+    // il ne doit pas être présent pour un étudiant
+    await expect(page.locator('.dh-new')).not.toBeVisible()
+  })
+
+})


### PR DESCRIPTION
## Contexte

Run automatique du 2026-06-18. Audit des flows E2E existants → 3 parcours critiques non couverts identifiés.

## Flows couverts

| Fichier | Flow | Priorité |
|---|---|---|
| `tests/e2e/student.spec.ts` | Login étudiant → dashboard (URL + app shell) | auth ★★★ |
| `tests/e2e/student.spec.ts` | Navigation `/devoirs` → vue étudiant sans bouton "Nouveau devoir" | devoirs ★★★ |
| `tests/e2e/messages.spec.ts` | Navigation `/messages` → `#main-area` + `#sidebar-channels-header` visibles | messages ★★ |

## Ce qui était déjà couvert (non dupliqué)

- `auth.spec.ts` : login enseignant, login invalide, affichage page login
- `demo-mode.spec.ts` : démarrage session démo étudiant/enseignant, API fallback
- `cross-promo-isolation.spec.ts` : isolation canaux/devoirs par promo (skipped, infra requise)

## Choix techniques

- `student.spec.ts` utilise `provisionStudent()` en `beforeAll` pour garantir l'existence du compte sans accumuler d'orphelins (idempotent via 409).
- Sélecteurs choisis sur des IDs/classes stables du DOM (`#app-shell`, `.devoirs-area`, `.dh-new`, `#main-area`, `#sidebar-channels-header`) plutôt que sur du texte, pour résister aux reformulations.
- Le bouton `.dh-new` est un `v-if="appStore.isTeacher"` dans `DevoirsHeader.vue` → son absence prouve que la session est bien étudiante.
- `#sidebar-channels-header` est rendu dans le bloc `v-else` de `Sidebar.vue` pour toutes les routes autres que dashboard/devoirs/documents/etc., donc toujours présent sur `/messages` après le chargement.

## Test plan

- [ ] `npm run test:e2e` passe en local avec `NODE_ENV=test`
- [ ] Le login étudiant redirige bien sur `/dashboard`
- [ ] La vue `/devoirs` affiche `.devoirs-area` sans `.dh-new`
- [ ] La vue `/messages` affiche `#main-area` et `#sidebar-channels-header`

https://claude.ai/code/session_01JS2sxaQk7KFpN5UPQSXEbD

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS2sxaQk7KFpN5UPQSXEbD)_