### PR TITLE
test(e2e): devoirs, messages et contrôle d'accès par rôle

### DIFF
--- a/tests/e2e/devoirs.spec.ts
+++ b/tests/e2e/devoirs.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test'
+import { loginAndWaitDashboard, navigateTo, provisionStudent, STUDENT } from './helpers'
+
+test.describe('Devoirs – parcours étudiant', () => {
+  test.beforeAll(async () => {
+    await provisionStudent()
+  })
+
+  test('un étudiant connecté accède à la page devoirs', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    await navigateTo(page, 'devoirs')
+    await expect(page).toHaveURL(/devoirs/, { timeout: 10_000 })
+    await expect(page.locator('.devoirs-area')).toBeVisible({ timeout: 15_000 })
+  })
+
+  test('la page devoirs se charge et affiche un état final cohérent', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    await navigateTo(page, 'devoirs')
+
+    // Attendre la fin du chargement : les squelettes disparaissent
+    await page.waitForFunction(
+      () => !document.querySelector('.skel-card'),
+      { timeout: 20_000 },
+    )
+
+    // État post-chargement : liste vide ou contenu réel
+    const emptyState = page.locator('.es-title', { hasText: 'Aucun devoir assigné' })
+    const devoirsContent = page.locator('.dv-page, .student-devoir-group, .sdv-search')
+    await expect(emptyState.or(devoirsContent)).toBeVisible({ timeout: 5_000 })
+  })
+})

--- a/tests/e2e/messages.spec.ts
+++ b/tests/e2e/messages.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test'
+import { loginAndWaitDashboard, navigateTo, TEACHER } from './helpers'
+
+test.describe('Messages – navigation enseignant', () => {
+  test('un enseignant accède à la vue messages', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    await navigateTo(page, 'messages')
+    await expect(page).toHaveURL(/messages/, { timeout: 10_000 })
+    await expect(page.locator('#main-area')).toBeVisible({ timeout: 15_000 })
+  })
+
+  test("cliquer sur un canal ouvre la conversation et affiche l'en-tête", async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    await navigateTo(page, 'messages')
+
+    // Attendre que la sidebar charge au moins un canal (pas un DM)
+    const firstChannel = page.locator('.sidebar-wrapper .sidebar-item:has(.channel-name)').first()
+    await expect(firstChannel).toBeVisible({ timeout: 20_000 })
+
+    await firstChannel.click()
+
+    // L'en-tête de canal doit apparaître avec le nom et la barre de recherche
+    await expect(page.locator('#channel-header')).toBeVisible({ timeout: 10_000 })
+    await expect(page.locator('#channel-name')).toBeVisible({ timeout: 5_000 })
+    await expect(page.locator('#search-input')).toBeVisible({ timeout: 5_000 })
+  })
+})

--- a/tests/e2e/role-guard.spec.ts
+++ b/tests/e2e/role-guard.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test'
+import { loginAndWaitDashboard, provisionStudent, STUDENT, TEACHER } from './helpers'
+
+test.describe("Contrôle d'accès – gardes de route", () => {
+  test.beforeAll(async () => {
+    await provisionStudent()
+  })
+
+  test("un étudiant est redirigé depuis /admin vers le dashboard", async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    await page.goto('/#/admin')
+    // Le niveau étudiant (0) est inférieur au niveau admin (3) requis
+    await expect(page).toHaveURL(/dashboard/, { timeout: 10_000 })
+  })
+
+  test("un étudiant est redirigé depuis /fichiers (route enseignant) vers le dashboard", async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    await page.goto('/#/fichiers')
+    // Route meta.requiredRole: 'teacher' → étudiant redirigé
+    await expect(page).toHaveURL(/dashboard/, { timeout: 10_000 })
+  })
+
+  test("un enseignant est redirigé depuis /admin vers le dashboard", async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    await page.goto('/#/admin')
+    // Le niveau teacher (2) est inférieur au niveau admin (3) requis
+    await expect(page).toHaveURL(/dashboard/, { timeout: 10_000 })
+  })
+})


### PR DESCRIPTION
## Flows E2E couverts

Avant cette PR, seuls 3 scénarios étaient testés end-to-end (login form, credentials invalides, login enseignant). Les parcours métier critiques n'étaient pas couverts.

### Nouveaux tests (7 scénarios)

#### `tests/e2e/devoirs.spec.ts` — Parcours étudiant Devoirs
- Un étudiant connecté peut naviguer vers `/devoirs` (URL + container `.devoirs-area` visible)
- La page se charge jusqu'à un état final cohérent : soit état vide « Aucun devoir assigné », soit la liste de devoirs réelle

#### `tests/e2e/messages.spec.ts` — Navigation enseignant Messages
- Un enseignant connecté accède à la vue `/messages` (`#main-area` visible)
- Cliquer sur un canal dans la sidebar ouvre la conversation et affiche l'en-tête (`#channel-header`, `#channel-name`, `#search-input`)

#### `tests/e2e/role-guard.spec.ts` — Gardes de route (sécurité)
- Un étudiant tentant d'accéder à `/admin` est redirigé vers `/dashboard`
- Un étudiant tentant d'accéder à `/fichiers` (route `meta.requiredRole: 'teacher'`) est redirigé
- Un enseignant tentant d'accéder à `/admin` (niveau 2 < admin niveau 3) est redirigé

### Couverture avant / après

| Flow | Avant | Après |
|------|-------|-------|
| Login / auth | ✅ basique | ✅ |
| Demo mode | ✅ complet | ✅ |
| Devoirs étudiant | ❌ | ✅ |
| Messages enseignant | ❌ | ✅ |
| Contrôle d'accès par rôle | ❌ | ✅ |

### Helpers réutilisés
- `provisionStudent()` — création idempotente du compte étudiant E2E via API
- `loginAndWaitDashboard()` — login + attente de `#app-shell`
- `navigateTo()` — click NavRail par section

### Vérification
- `npx tsc --noEmit` passe sans erreur (seul avertissement de dépréciation `baseUrl` pré-existant)
- Patrons identiques aux tests existants `auth.spec.ts` / `demo-mode.spec.ts`


---
_Generated by [Claude Code](https://claude.ai/code/session_01W3rE1QuPsqDqPst8Fx8DvG)_