### PR TITLE
test(e2e): couvrir devoirs, messages et gardes de route (auto 2026-06-29)

### DIFF
--- a/tests/e2e/devoirs.spec.ts
+++ b/tests/e2e/devoirs.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test'
+import { TEACHER, STUDENT, loginAndWaitDashboard, navigateTo, provisionStudent } from './helpers'
+
+test.describe('Devoirs', () => {
+  test.beforeAll(async () => {
+    await provisionStudent()
+  })
+
+  test('etudiant voit la section devoirs avec sa vue personnelle', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    await navigateTo(page, 'devoirs')
+    // Le conteneur principal doit etre monte : devoirs-area > devoirs-content
+    await expect(page.locator('.devoirs-area')).toBeVisible({ timeout: 10_000 })
+    await expect(page.locator('.devoirs-content')).toBeVisible({ timeout: 10_000 })
+    // L'URL doit rester sur /devoirs (pas de redirection inattendue)
+    await expect(page).toHaveURL(/devoirs/)
+  })
+
+  test('enseignant voit la vue gestion des devoirs', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    await navigateTo(page, 'devoirs')
+    await expect(page.locator('.devoirs-area')).toBeVisible({ timeout: 10_000 })
+    await expect(page.locator('.devoirs-content')).toBeVisible({ timeout: 10_000 })
+    // L'enseignant ne voit pas la vue etudiante (StudentDevoirsView n'est pas rendue)
+    await expect(page.locator('.devoirs-list').first()).not.toBeVisible({ timeout: 5_000 })
+  })
+})

--- a/tests/e2e/messages.spec.ts
+++ b/tests/e2e/messages.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test'
+import { TEACHER, STUDENT, loginAndWaitDashboard, navigateTo, provisionStudent } from './helpers'
+
+test.describe('Messages', () => {
+  test.beforeAll(async () => {
+    await provisionStudent()
+  })
+
+  test('enseignant accede a la section messages et voit la zone de chat', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    await navigateTo(page, 'messages')
+    // La zone principale (id=main-area, toujours presente dans MessagesView) doit etre visible
+    await expect(page.locator('#main-area')).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('etudiant accede a la section messages et voit la zone de chat', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    await navigateTo(page, 'messages')
+    await expect(page.locator('#main-area')).toBeVisible({ timeout: 10_000 })
+  })
+})

--- a/tests/e2e/route-guards.spec.ts
+++ b/tests/e2e/route-guards.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test'
+import { TEACHER, STUDENT, loginAndWaitDashboard, provisionStudent } from './helpers'
+
+/**
+ * Verifie que le guard de route (router.beforeEach) redirige les utilisateurs
+ * vers /dashboard quand ils tentent d'acceder a une route dont le role requis
+ * depasse leur niveau (etudiant -> teacher/admin).
+ */
+test.describe('Controles d\'acces par role', () => {
+  test.beforeAll(async () => {
+    await provisionStudent()
+  })
+
+  test('etudiant est redirige de /admin vers le dashboard', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    // /admin requiert le role 'admin' ; un etudiant doit etre redirige
+    await page.goto('/#/admin')
+    await expect(page).toHaveURL(/dashboard/, { timeout: 10_000 })
+  })
+
+  test('etudiant est redirige de /booking vers le dashboard', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    // /booking requiert le role 'teacher' ; un etudiant doit etre redirige
+    await page.goto('/#/booking')
+    await expect(page).toHaveURL(/dashboard/, { timeout: 10_000 })
+  })
+
+  test('enseignant peut acceder a /booking sans redirection', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    await page.goto('/#/booking')
+    // Un enseignant satisfait la contrainte requiredRole:'teacher'
+    await expect(page).toHaveURL(/booking/, { timeout: 10_000 })
+    // L'app-shell doit etre present : la page est bien montee, pas d'erreur fatale
+    await expect(page.locator('#app-shell, .app-shell, .app-columns')).toBeVisible({ timeout: 10_000 })
+  })
+})


### PR DESCRIPTION
## Flows couverts

Trois nouveaux fichiers de tests Playwright couvrant les parcours critiques non encore testés, par ordre de priorité :

### `tests/e2e/devoirs.spec.ts`
- **Étudiant → /devoirs** : après login, navigation vers la section Devoirs, vérification que `.devoirs-area` et `.devoirs-content` sont montés, et que l'URL reste sur `/devoirs`.
- **Enseignant → /devoirs** : idem, et vérification que la vue étudiante (`StudentDevoirsView / .devoirs-list`) n'est **pas** rendue côté prof.

### `tests/e2e/messages.spec.ts`
- **Enseignant → /messages** : navigation vers la section Messages, présence du conteneur principal `#main-area`.
- **Étudiant → /messages** : même vérification côté étudiant.

### `tests/e2e/route-guards.spec.ts`
- **Étudiant → /admin** : le guard `router.beforeEach` doit rediriger vers `/dashboard` (rôle `admin` requis).
- **Étudiant → /booking** : même redirection (rôle `teacher` requis).
- **Enseignant → /booking** : accès autorisé — URL reste sur `/booking` et l'app-shell est visible.

## Ce qui n'est PAS dupliqué

| Flow déjà couvert | Fichier existant |
|---|---|
| Login valide / invalide, login enseignant | `auth.spec.ts` |
| Mode démo étudiant / enseignant, fallback API | `demo-mode.spec.ts` |
| Isolation cross-promo (skippé) | `cross-promo-isolation.spec.ts` |

## Helpers utilisés

Tous les tests réutilisent `loginAndWaitDashboard`, `navigateTo` et `provisionStudent` depuis `helpers.ts`. Le compte étudiant de test (`e2e-student@test.fr`) est provisionné via `beforeAll` dans chaque fichier qui en a besoin.

## Vérification syntaxique

`npx tsc --noEmit` : seule l'alerte pré-existante `TS5101` (deprecation `baseUrl`) est remontée — aucune erreur dans les nouveaux fichiers.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VgNfiz3WtAJh2tV3qhJkd6)_