### PR TITLE
test(e2e): nouveaux specs Playwright — devoirs, messages et garde-fous de routes

### DIFF
--- a/tests/e2e/devoirs.spec.ts
+++ b/tests/e2e/devoirs.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test'
+import {
+  TEACHER,
+  STUDENT,
+  provisionStudent,
+  loginAndWaitDashboard,
+  navigateTo,
+} from './helpers'
+
+test.describe('Devoirs', () => {
+  test('enseignant accede a la vue devoirs et voit la zone de contenu', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    await navigateTo(page, 'devoirs')
+    await expect(page.locator('.devoirs-area')).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('etudiant accede a la vue devoirs apres provisioning', async ({ page }) => {
+    await provisionStudent()
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    await navigateTo(page, 'devoirs')
+    await expect(page.locator('.devoirs-area')).toBeVisible({ timeout: 10_000 })
+  })
+})

--- a/tests/e2e/messages.spec.ts
+++ b/tests/e2e/messages.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from '@playwright/test'
+import { TEACHER, loginAndWaitDashboard, navigateTo } from './helpers'
+
+test.describe('Messages', () => {
+  test('enseignant accede a la vue messages et voit la zone principale', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    await navigateTo(page, 'messages')
+    // #main-area est l'element racine de MessagesView, present quelque soit le canal actif
+    await expect(page.locator('#main-area')).toBeVisible({ timeout: 10_000 })
+  })
+})

--- a/tests/e2e/route-guards.spec.ts
+++ b/tests/e2e/route-guards.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test'
+import { STUDENT, provisionStudent, loginAndWaitDashboard } from './helpers'
+
+test.describe('Garde-fous de routes (role-based guards)', () => {
+  test.beforeEach(async () => {
+    await provisionStudent()
+  })
+
+  test('etudiant redirige vers /dashboard quand il tente /admin', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    // Tentative d'acces direct a la route admin (requiredRole: 'admin')
+    await page.goto('/#/admin')
+    await expect(page).toHaveURL(/dashboard/, { timeout: 10_000 })
+  })
+
+  test('etudiant redirige vers /dashboard quand il tente /booking (enseignant seulement)', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    // Tentative d'acces direct a la route booking (requiredRole: 'teacher')
+    await page.goto('/#/booking')
+    await expect(page).toHaveURL(/dashboard/, { timeout: 10_000 })
+  })
+})

--- a/tests/e2e/tsconfig.e2e.json
+++ b/tests/e2e/tsconfig.e2e.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "lib": ["ES2020", "DOM"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["./*.ts"]
+}


### PR DESCRIPTION
## Description

Ajout de 3 nouveaux fichiers de tests E2E Playwright couvrant les flows critiques non testés : devoirs, messages et protection des routes par rôle.

**Flows couverts :**
- `devoirs.spec.ts` — Enseignant et étudiant accèdent à `/devoirs`, vérifie que `.devoirs-area` est visible (StudentDevoirsView vs TeacherProjectHome selon le rôle)
- `messages.spec.ts` — Enseignant accède à `/messages`, vérifie que `#main-area` (racine de MessagesView) est visible
- `route-guards.spec.ts` — Un étudiant tenté d'accéder à `/admin` (`requiredRole: 'admin'`) ou `/booking` (`requiredRole: 'teacher'`) est redirigé vers `/dashboard` par le guard Vue Router

**Déjà couverts (non dupliqués) :** auth (login/erreur/redirect), demo mode (étudiant/enseignant/fallback API), isolation cross-promo (skip).

Un `tsconfig.e2e.json` est ajouté dans `tests/e2e/` pour permettre `npx tsc --noEmit` sur les specs sans toucher aux tsconfigs existants.

## Type de changement

- [ ] Bug fix
- [ ] Nouvelle fonctionnalite
- [x] Refactoring (pas de changement fonctionnel)
- [ ] Documentation
- [ ] CI/CD
- [x] Autre : Tests E2E automatiques

## Checklist

- [x] Le code compile sans erreur (`npx vue-tsc --noEmit`)
- [x] Les tests passent (`npm test`)
- [x] Les changements sont testes manuellement
- [x] Le code suit les conventions du projet (pas de `any`, composables documentes)
- [ ] Les nouveaux fichiers ont un header `/** */`

## Captures d'ecran

N/A — tests headless.

## Notes pour le reviewer

- Les tests `devoirs` et `messages` requièrent un serveur démarré avec au moins `rfosse@cesi.fr` en base (teacher seedé par `schema v12`).
- Le `provisionStudent()` dans les tests étudiant est idempotent (ignore 409 si l'étudiant existe déjà).
- Les sélecteurs utilisés (`.devoirs-area`, `#main-area`) sont les éléments racine des vues respectives — robustes aux changements internes des composants enfants.
- `route-guards.spec.ts` utilise `page.goto('/#/admin')` pour forcer une navigation directe ; le guard Vue Router lit `localStorage.cc_session.type` et redirige vers `/dashboard`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01K4ozUB9RMhJ9gnVjBb6Rzw)_