### PR TITLE
test(e2e): couverture Playwright pour devoirs, auth étudiant et garde des routes

### DIFF
--- a/tests/e2e/devoirs.spec.ts
+++ b/tests/e2e/devoirs.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from '@playwright/test'
+import { TEACHER, loginAndWaitDashboard, navigateTo } from './helpers'
+
+test.describe('Devoirs', () => {
+  test('enseignant navigue vers les devoirs et voit la vue projets', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    await navigateTo(page, 'devoirs')
+    // La div racine de DevoirsView doit être rendue
+    await expect(page.locator('.devoirs-area')).toBeVisible({ timeout: 10_000 })
+  })
+})

--- a/tests/e2e/role-guard.spec.ts
+++ b/tests/e2e/role-guard.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from '@playwright/test'
+import { TEACHER, loginAndWaitDashboard } from './helpers'
+
+test.describe('Garde des routes par rôle', () => {
+  test('enseignant redirigé vers /dashboard en accédant à /admin (rôle admin requis)', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    // Tentative d'accès direct à la route protégée
+    await page.goto('/#/admin')
+    // Le router guard doit rediriger vers /dashboard
+    await expect(page).toHaveURL(/dashboard/, { timeout: 10_000 })
+  })
+})

--- a/tests/e2e/student-auth.spec.ts
+++ b/tests/e2e/student-auth.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test'
+import { STUDENT, provisionStudent, loginAndWaitDashboard, navigateTo } from './helpers'
+
+test.describe('Authentification étudiant', () => {
+  test.beforeAll(async () => {
+    await provisionStudent()
+  })
+
+  test('étudiant se connecte, voit le dashboard et accède aux devoirs', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    await expect(page).toHaveURL(/dashboard/, { timeout: 10_000 })
+    await expect(page.locator('#app-shell, .app-shell, .app-columns')).toBeVisible()
+
+    // L'étudiant peut naviguer vers les devoirs
+    await navigateTo(page, 'devoirs')
+    await expect(page.locator('.devoirs-area')).toBeVisible({ timeout: 10_000 })
+  })
+})

--- a/tsconfig.e2e.json
+++ b/tsconfig.e2e.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "lib": ["ES2020", "DOM"],
+    "types": ["node"],
+    "esModuleInterop": true,
+    "noEmit": true
+  },
+  "include": ["tests/e2e/**/*.ts"]
+}


### PR DESCRIPTION
## Description

Ajout de 3 tests Playwright couvrant des flows critiques absents de la suite E2E existante (qui ne testait que le login enseignant, les erreurs de login et le mode démo).

**Flows couverts :**

| Fichier | Flow | Priorité |
|---|---|---|
| `tests/e2e/devoirs.spec.ts` | Enseignant navigue vers `/devoirs` et voit `.devoirs-area` | Devoirs |
| `tests/e2e/student-auth.spec.ts` | Provisioning API de l'étudiant E2E, login, puis navigation vers `/devoirs` | Auth (étudiant) |
| `tests/e2e/role-guard.spec.ts` | Enseignant accédant directement à `/#/admin` est redirigé vers `/dashboard` | Admin / sécurité |

Le fichier `tsconfig.e2e.json` (ajouté à la racine) permet la vérification de types sur `tests/e2e/**` indépendamment du `tsconfig.json` principal — `npx tsc --noEmit -p tsconfig.e2e.json` passe sans erreur.

## Type de changement

- [ ] Bug fix
- [ ] Nouvelle fonctionnalite
- [x] Refactoring (pas de changement fonctionnel)
- [ ] Documentation
- [ ] CI/CD
- [x] Autre : Tests E2E

## Checklist

- [x] Le code compile sans erreur (`npx tsc --noEmit -p tsconfig.e2e.json`)
- [ ] Les tests passent (`npm test`)
- [x] Les changements sont testes manuellement
- [x] Le code suit les conventions du projet (pas de `any`, helpers réutilisés depuis `helpers.ts`)
- [ ] Les nouveaux fichiers ont un header `/** */`

## Notes pour le reviewer

- Les tests réutilisent les helpers existants (`loginAndWaitDashboard`, `navigateTo`, `provisionStudent`) — aucune duplication.
- `student-auth.spec.ts` appelle `provisionStudent()` dans un `beforeAll` ; l'étudiant de test est idempotent (tolère le 409 si déjà créé).
- La garde de route (`role-guard.spec.ts`) valide que le `beforeEach` du router Vue Router redirige un enseignant hors d'une route `requiredRole: 'admin'`.
- Les tests nécessitent un serveur en écoute sur le port 3001 (cf. `playwright.config.ts`) — ils ne tournent pas en offline.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELFyAuu1PmycFJsGSHmMgQ)_