### PR TITLE
test(e2e): couverture devoirs, messages et route guards

### DIFF
--- a/tests/e2e/devoirs.spec.ts
+++ b/tests/e2e/devoirs.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test'
+import { startDemo, navigateTo } from './helpers'
+
+test.describe('Devoirs', () => {
+
+  test('enseignant demo : page devoirs affiche le header et le CTA "Nouveau devoir"', async ({ page }) => {
+    await startDemo(page, 'Enseignant')
+    await navigateTo(page, 'devoirs')
+
+    // Le titre "Devoirs" du header doit etre rendu
+    await expect(page.locator('.dh-title-text')).toBeVisible({ timeout: 10_000 })
+    await expect(page.locator('.dh-title-text')).toHaveText('Devoirs')
+
+    // Le CTA "Nouveau devoir" est reserve aux enseignants
+    await expect(page.locator('button:has-text("Nouveau devoir")')).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('etudiant demo : page devoirs charge sans afficher le CTA enseignant', async ({ page }) => {
+    await startDemo(page, 'Etudiant')
+    await navigateTo(page, 'devoirs')
+
+    // La zone devoirs doit etre rendue
+    await expect(page.locator('.devoirs-area')).toBeVisible({ timeout: 10_000 })
+
+    // Un etudiant ne doit pas voir le bouton de creation de devoir
+    await expect(page.locator('button:has-text("Nouveau devoir")')).not.toBeVisible()
+  })
+
+})

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -75,6 +75,21 @@ export async function loginAndWaitDashboard(page: Page, email: string, password:
   await page.waitForTimeout(1_000)
 }
 
+/** Demarre une session demo et attend la redirection vers /dashboard */
+export async function startDemo(page: Page, role: 'Etudiant' | 'Enseignant'): Promise<void> {
+  await page.goto('/#/demo')
+  await page.waitForSelector(`button:has-text("${role}")`, { timeout: 20_000 })
+  const [res] = await Promise.all([
+    page.waitForResponse(
+      (r) => r.url().includes('/api/demo/start') && r.request().method() === 'POST',
+      { timeout: 20_000 },
+    ),
+    page.click(`button:has-text("${role}")`),
+  ])
+  if (!res.ok()) throw new Error(`Demo start failed for role ${role}: HTTP ${res.status()}`)
+  await expect(page).toHaveURL(/dashboard/, { timeout: 20_000 })
+}
+
 /** Navigue vers une section via le bouton NavRail (aria-label) */
 export async function navigateTo(page: Page, section: 'messages' | 'devoirs' | 'documents' | 'dashboard'): Promise<void> {
   // Capitaliser le nom de section pour le matching texte

--- a/tests/e2e/messages.spec.ts
+++ b/tests/e2e/messages.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test'
+import { TEACHER, loginAndWaitDashboard, navigateTo } from './helpers'
+
+test.describe('Messages', () => {
+
+  test('enseignant navigue vers messages et voit la zone principale de chat', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    await navigateTo(page, 'messages')
+
+    // La zone principale #main-area est toujours rendue une fois sur /messages
+    await expect(page.locator('#main-area')).toBeVisible({ timeout: 10_000 })
+  })
+
+})

--- a/tests/e2e/route-guards.spec.ts
+++ b/tests/e2e/route-guards.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test'
+import { startDemo } from './helpers'
+
+/**
+ * Verifie que le guard de route front (beforeEach dans router/index.ts)
+ * bloque l'acces a /admin pour les roles insuffisants.
+ * La route /admin requiert requiredRole: 'admin' (niveau 3).
+ * Les roles 'student' (0) et 'teacher' (2) doivent etre rediriges vers /dashboard.
+ */
+
+test.describe('Route guards', () => {
+
+  test('etudiant demo est redirige depuis /admin vers /dashboard', async ({ page }) => {
+    await startDemo(page, 'Etudiant')
+
+    // Tente d'acceder directement a la route admin
+    await page.goto('/#/admin')
+
+    // Le guard de role doit rediriger vers /dashboard
+    await expect(page).toHaveURL(/dashboard/, { timeout: 5_000 })
+  })
+
+  test('enseignant demo est redirige depuis /admin vers /dashboard', async ({ page }) => {
+    await startDemo(page, 'Enseignant')
+
+    // Le role 'teacher' (niveau 2) est insuffisant pour /admin (niveau 3 = admin)
+    await page.goto('/#/admin')
+
+    // Le guard doit tout de meme rediriger
+    await expect(page).toHaveURL(/dashboard/, { timeout: 5_000 })
+  })
+
+})

--- a/tests/e2e/tsconfig.json
+++ b/tests/e2e/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "Node16",
+    "moduleResolution": "node16",
+    "lib": ["ES2020", "DOM"],
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true
+  },
+  "include": ["./**/*.ts"]
+}


### PR DESCRIPTION
## Flows couverts

Trois fichiers de tests Playwright ajoutés pour les parcours critiques non encore couverts (par ordre de priorité) :

### `tests/e2e/devoirs.spec.ts`
- **Enseignant demo** : navigue vers `/devoirs`, vérifie que le header `.dh-title-text` affiche "Devoirs" et que le CTA `Nouveau devoir` est visible
- **Etudiant demo** : navigue vers `/devoirs`, vérifie que `.devoirs-area` est rendu et que le CTA enseignant n'est **pas** visible

### `tests/e2e/messages.spec.ts`
- **Enseignant** : login réel, navigation vers `/messages`, vérification que `#main-area` est rendu

### `tests/e2e/route-guards.spec.ts`
- **Etudiant demo** : tentative d'accès à `/admin` → redirigé vers `/dashboard` (role `student` niveau 0 < `admin` niveau 3)
- **Enseignant demo** : même vérification (role `teacher` niveau 2 < `admin` niveau 3)

## Infrastructure

- **`tests/e2e/helpers.ts`** : ajout de `startDemo(page, role)` pour factoriser le démarrage de session demo (réutilisé par devoirs et route-guards)
- **`tests/e2e/tsconfig.json`** : config TypeScript dédiée aux tests E2E — permet `npx tsc --noEmit -p tests/e2e/tsconfig.json` ✅

## Ce qui n'est pas dupliqué

| Flow déjà couvert | Fichier existant |
|---|---|
| Affichage login, login invalide, login enseignant → dashboard | `auth.spec.ts` |
| Demo landing, start student/teacher, fallback API | `demo-mode.spec.ts` |
| Isolation cross-promo (canaux + devoirs) | `cross-promo-isolation.spec.ts` (skipped, seed requis) |

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDYrbERrPacLc6Jhz34xEk)_