### PR TITLE
test(e2e): devoirs & messages flow coverage

### DIFF
--- a/tests/e2e/devoirs.spec.ts
+++ b/tests/e2e/devoirs.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test'
+import { TEACHER, STUDENT, loginAndWaitDashboard, navigateTo, provisionStudent } from './helpers'
+
+test.describe('Devoirs', () => {
+  test.beforeAll(async () => {
+    await provisionStudent()
+  })
+
+  test('enseignant : accède à la vue devoirs avec le bouton "Nouveau devoir"', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    await navigateTo(page, 'devoirs')
+    await expect(page.locator('.devoirs-area')).toBeVisible({ timeout: 15_000 })
+    await expect(page.locator('button.dh-new, button:has-text("Nouveau devoir")')).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('étudiant : accède à la vue devoirs sans le bouton "Nouveau devoir"', async ({ page }) => {
+    await loginAndWaitDashboard(page, STUDENT.email, STUDENT.password)
+    await navigateTo(page, 'devoirs')
+    await expect(page.locator('.devoirs-area')).toBeVisible({ timeout: 15_000 })
+    await expect(page.locator('button.dh-new')).not.toBeVisible()
+  })
+})

--- a/tests/e2e/messages.spec.ts
+++ b/tests/e2e/messages.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test'
+import { TEACHER, loginAndWaitDashboard, navigateTo } from './helpers'
+
+test.describe('Messages', () => {
+  test('enseignant : affiche le message de bienvenue quand aucun canal n\'est sélectionné', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    await navigateTo(page, 'messages')
+    await expect(page.locator('#no-channel-hint, .no-channel-hint')).toBeVisible({ timeout: 15_000 })
+    await expect(page.locator('#no-channel-hint, .no-channel-hint')).toContainText('Bienvenue')
+  })
+
+  test('enseignant : sélectionne un canal et affiche son en-tête', async ({ page }) => {
+    await loginAndWaitDashboard(page, TEACHER.email, TEACHER.password)
+    await navigateTo(page, 'messages')
+    const firstChannel = page.locator('.sidebar-item').first()
+    const hasChannel = await firstChannel.isVisible({ timeout: 8_000 }).catch(() => false)
+    if (!hasChannel) {
+      test.skip(true, 'Aucun canal disponible dans la base de données de test')
+    }
+    await firstChannel.click()
+    await expect(page.locator('#channel-header')).toBeVisible({ timeout: 15_000 })
+    await expect(page.locator('#channel-name')).toBeVisible()
+    await expect(page.locator('#search-input')).toBeVisible()
+  })
+})

--- a/tsconfig.e2e.json
+++ b/tsconfig.e2e.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "Node16",
+    "moduleResolution": "node16",
+    "lib": ["ES2020", "DOM"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "typeRoots": ["./node_modules/@types"]
+  },
+  "include": [
+    "tests/e2e/**/*.ts",
+    "playwright.config.ts"
+  ]
+}


### PR DESCRIPTION
## Description

Ajout de 2 nouveaux fichiers de tests E2E Playwright couvrant les flows **Devoirs** et **Messages**, identifiés comme les parcours critiques non couverts après analyse des tests existants.

**Couverture existante avant cette PR :**
- `auth.spec.ts` — affichage login, login invalide, connexion enseignant → dashboard
- `demo-mode.spec.ts` — demo étudiant/enseignant, endpoints fallback
- `cross-promo-isolation.spec.ts` — isolation inter-promo (skipped, setup spécial requis)

**Nouveaux flows couverts :**

### `tests/e2e/devoirs.spec.ts`
- **Enseignant** : login → navigation vers `/devoirs` → `.devoirs-area` visible + bouton `Nouveau devoir` présent (rendu conditionnel par rôle)
- **Étudiant** : login → navigation vers `/devoirs` → `.devoirs-area` visible + bouton `Nouveau devoir` absent (vérification du guard `v-if="appStore.isTeacher"`)

### `tests/e2e/messages.spec.ts`
- **No-channel state** : enseignant sur `/messages` sans canal sélectionné → `#no-channel-hint` visible avec texte "Bienvenue"
- **Channel selection** : enseignant clique sur le premier `.sidebar-item` → `#channel-header`, `#channel-name` et `#search-input` visibles (skip automatique si aucun canal n'est seeded)

### `tsconfig.e2e.json`
Tsconfig dédié pour type-checker les fichiers E2E (`npx tsc --noEmit --project tsconfig.e2e.json`) — les tsconfig existants (`tsconfig.json`, `tsconfig.node.json`) n'incluaient pas `tests/`.

## Type de changement

- [x] Autre : tests E2E automatisés

## Checklist

- [x] Le code compile sans erreur (`npx tsc --noEmit --project tsconfig.e2e.json`)
- [ ] Les tests passent (`npm test`) — nécessite serveur + seed en cours d'exécution
- [x] Les changements sont testés manuellement (vérification syntaxique TypeScript)
- [x] Le code suit les conventions du projet (patterns identiques aux specs existantes)

## Notes pour le reviewer

- La priorité des flows suivie est celle du prompt : auth > devoirs > messages. Auth étant déjà couvert, cette PR se concentre sur devoirs et messages.
- Le test `messages : sélectionne un canal` effectue un `test.skip` conditionnel si aucun canal n'est disponible dans la base — comportement robuste pour les environnements sans seed complet.
- Le `provisionStudent()` dans `beforeAll` de `devoirs.spec.ts` est idempotent (ignore les 409).

---
_Generated by [Claude Code](https://claude.ai/code/session_01LVGMVeULeuee61AiayAN45)_